### PR TITLE
Extend the database for a upcoming feature before release

### DIFF
--- a/types.go
+++ b/types.go
@@ -72,6 +72,7 @@ type ACMETxt struct {
 	Password string
 	ACMETxtPost
 	LastActive int64
+	AllowFrom  string
 }
 
 // ACMETxtPost holds the DNS part of the ACMETxt struct


### PR DESCRIPTION
Extend the database to accommodate data for feature that allows limiting update requests per CIDR mask.