### PR TITLE
Implement possibility to provide a list of CIDR ranges to limit update request origins

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ With the credentials, you can update the TXT response in the service to match th
     "allowfrom": [
         "192.168.100.1/24",
         "1.2.3.4/32",
-        "2002:c0a8:2a01::0/32",
+        "2002:c0a8:2a00::0/40",
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -21,8 +21,7 @@ So basically it boils down to **accessibility** and **security**
 - Simple deployment (it's Go after all)
 
 ## Usage
-
-[![asciicast](https://asciinema.org/a/94462.png)](https://asciinema.org/a/94462)
+[![asciicast](https://asciinema.org/a/94903.png)](https://asciinema.org/a/94903)
 
 Using acme-dns is a three-step process (provided you already have the self-hosted server set up, or are using a service like acme-dns.io):
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A simplified DNS server with a RESTful HTTP API to provide a simple way to autom
 Many DNS servers do not provide an API to enable automation for the ACME DNS challenges. Those which do, give the keys way too much power.
 Leaving the keys laying around your random boxes is too often a requirement to have a meaningful process automation.
 
-Acme-dns provides a simple API exclusively for TXT record updates and should be used with ACME magic "\_acme-challenge" - subdomain CNAME records. This way in the unfortunate exposure of API keys, the effetcs are limited to the subdomain TXT record in question.
+Acme-dns provides a simple API exclusively for TXT record updates and should be used with ACME magic "\_acme-challenge" - subdomain CNAME records. This way, in the unfortunate exposure of API keys, the effetcs are limited to the subdomain TXT record in question.
 
 So basically it boils down to **accessibility** and **security**
 
@@ -48,6 +48,7 @@ With the credentials, you can update the TXT response in the service to match th
     "allowfrom": [
         "192.168.100.1/24",
         "1.2.3.4/32",
+        "2002:c0a8:2a01::0/32",
 }
 ```
 

--- a/acmetxt.go
+++ b/acmetxt.go
@@ -57,6 +57,17 @@ func (a ACMETxt) allowedFrom(ip string) bool {
 	return false
 }
 
+// Go through list (most likely from headers) to check for the IP.
+// Reason for this is that some setups use reverse proxy in front of acme-dns
+func (a ACMETxt) allowedFromList(ips []string) bool {
+	for _, v := range ips {
+		if a.allowedFrom(v) {
+			return true
+		}
+	}
+	return false
+}
+
 func newACMETxt() ACMETxt {
 	var a = ACMETxt{}
 	password := generatePassword(40)

--- a/acmetxt.go
+++ b/acmetxt.go
@@ -41,6 +41,22 @@ func (c *cidrslice) ValidEntries() []string {
 	return valid
 }
 
+// Check if IP belongs to an allowed net
+func (a ACMETxt) allowedFrom(ip string) bool {
+	remoteIP := net.ParseIP(ip)
+	// Range not limited
+	if len(a.AllowFrom.ValidEntries()) == 0 {
+		return true
+	}
+	for _, v := range a.AllowFrom.ValidEntries() {
+		_, vnet, _ := net.ParseCIDR(v)
+		if vnet.Contains(remoteIP) {
+			return true
+		}
+	}
+	return false
+}
+
 func newACMETxt() ACMETxt {
 	var a = ACMETxt{}
 	password := generatePassword(40)

--- a/acmetxt.go
+++ b/acmetxt.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"encoding/json"
+	"net"
+
+	"github.com/satori/go.uuid"
+)
+
+// ACMETxt is the default structure for the user controlled record
+type ACMETxt struct {
+	Username uuid.UUID
+	Password string
+	ACMETxtPost
+	LastActive int64
+	AllowFrom  cidrslice
+}
+
+// ACMETxtPost holds the DNS part of the ACMETxt struct
+type ACMETxtPost struct {
+	Subdomain string `json:"subdomain"`
+	Value     string `json:"txt"`
+}
+
+// cidrslice is a list of allowed cidr ranges
+type cidrslice []string
+
+func (c *cidrslice) JSON() string {
+	ret, _ := json.Marshal(c.ValidEntries())
+	return string(ret)
+}
+
+func (c *cidrslice) ValidEntries() []string {
+	valid := []string{}
+	for _, v := range *c {
+		_, _, err := net.ParseCIDR(v)
+		if err == nil {
+			valid = append(valid, v)
+		}
+	}
+	return valid
+}
+
+func newACMETxt() ACMETxt {
+	var a = ACMETxt{}
+	password := generatePassword(40)
+	a.Username = uuid.NewV4()
+	a.Password = password
+	a.Subdomain = uuid.NewV4().String()
+	return a
+}

--- a/api.go
+++ b/api.go
@@ -58,17 +58,17 @@ func (a authMiddleware) Serve(ctx *iris.Context) {
 func webRegisterPost(ctx *iris.Context) {
 	var regJSON iris.Map
 	var regStatus int
-	cslice := cidrslice{}
-	_ = ctx.ReadJSON(&cslice)
+	aTXT := ACMETxt{}
+	_ = ctx.ReadJSON(&aTXT)
 	// Create new user
-	nu, err := DB.Register(cslice)
+	nu, err := DB.Register(aTXT.AllowFrom)
 	if err != nil {
 		errstr := fmt.Sprintf("%v", err)
 		regJSON = iris.Map{"error": errstr}
 		regStatus = iris.StatusInternalServerError
 		log.WithFields(log.Fields{"error": err.Error()}).Debug("Error in registration")
 	} else {
-		regJSON = iris.Map{"username": nu.Username, "password": nu.Password, "fulldomain": nu.Subdomain + "." + DNSConf.General.Domain, "subdomain": nu.Subdomain, "allowfrom": nu.AllowFrom.JSON()}
+		regJSON = iris.Map{"username": nu.Username, "password": nu.Password, "fulldomain": nu.Subdomain + "." + DNSConf.General.Domain, "subdomain": nu.Subdomain, "allowfrom": nu.AllowFrom.ValidEntries()}
 		regStatus = iris.StatusCreated
 
 		log.WithFields(log.Fields{"user": nu.Username.String()}).Debug("Created new user")

--- a/api_test.go
+++ b/api_test.go
@@ -228,6 +228,11 @@ func TestApiManyUpdateWithIpCheckHeaders(t *testing.T) {
 		t.Errorf("Could not create new user with CIDR, got error [%v]", err)
 	}
 
+	newUserWithIP6CIDR, err := DB.Register(cidrslice{"2002:c0a8::0/32"})
+	if err != nil {
+		t.Errorf("Could not create a new user with IP6 CIDR, got error [%v]", err)
+	}
+
 	for _, test := range []struct {
 		user        ACMETxt
 		headerValue string
@@ -238,6 +243,9 @@ func TestApiManyUpdateWithIpCheckHeaders(t *testing.T) {
 		{newUserWithCIDR, "127.0.0.1", 401},
 		{newUserWithCIDR, "10.0.0.1, 10.0.0.2, 192.168.1.3", 401},
 		{newUserWithCIDR, "10.1.1.1 ,192.168.1.2, 8.8.8.8", 200},
+		{newUserWithIP6CIDR, "2002:c0a8:b4dc:0d3::0", 200},
+		{newUserWithIP6CIDR, "2002:c0a7:0ff::0", 401},
+		{newUserWithIP6CIDR, "2002:c0a8:d3ad:b33f:c0ff:33b4:dc0d:3b4d", 200},
 	} {
 		updateJSON = map[string]interface{}{
 			"subdomain": test.user.Subdomain,

--- a/api_test.go
+++ b/api_test.go
@@ -90,7 +90,7 @@ func TestApiUpdateWithCredentials(t *testing.T) {
 		"txt":       ""}
 
 	e := setupIris(t, false, false)
-	newUser, err := DB.Register()
+	newUser, err := DB.Register(cidrslice{})
 	if err != nil {
 		t.Errorf("Could not create new user, got error [%v]", err)
 	}
@@ -146,7 +146,7 @@ func TestApiManyUpdateWithCredentials(t *testing.T) {
 		"txt":       ""}
 
 	e := setupIris(t, false, false)
-	newUser, err := DB.Register()
+	newUser, err := DB.Register(cidrslice{})
 	if err != nil {
 		t.Errorf("Could not create new user, got error [%v]", err)
 	}
@@ -164,6 +164,7 @@ func TestApiManyUpdateWithCredentials(t *testing.T) {
 		{newUser.Username.String(), newUser.Password, newUser.Subdomain, "tooshortfortxt", 400},
 		{newUser.Username.String(), newUser.Password, newUser.Subdomain, 1234567890, 400},
 		{newUser.Username.String(), newUser.Password, newUser.Subdomain, validTxtData, 200},
+		{newUser.Username.String(), "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", newUser.Subdomain, validTxtData, 401},
 	} {
 		updateJSON = map[string]interface{}{
 			"subdomain": test.subdomain,

--- a/api_test.go
+++ b/api_test.go
@@ -50,10 +50,10 @@ func TestApiRegister(t *testing.T) {
 		ContainsKey("password").
 		NotContainsKey("error")
 
-	allowfrom := []interface{}{
-		"123.123.123.123/32",
-		"1010.10.10.10/24",
-		"invalid",
+	allowfrom := map[string][]interface{}{
+		"allowfrom": []interface{}{"123.123.123.123/32",
+			"1010.10.10.10/24",
+			"invalid"},
 	}
 
 	response := e.POST("/register").
@@ -68,8 +68,7 @@ func TestApiRegister(t *testing.T) {
 		ContainsKey("allowfrom").
 		NotContainsKey("error")
 
-	response.Value("allowfrom").String().Equal("[\"123.123.123.123/32\"]")
-
+	response.Value("allowfrom").Array().Elements("123.123.123.123/32")
 }
 
 func TestApiRegisterWithMockDB(t *testing.T) {

--- a/api_test.go
+++ b/api_test.go
@@ -177,11 +177,6 @@ func TestApiManyUpdateWithCredentials(t *testing.T) {
 		t.Errorf("Could not create new user with a valid CIDR, got error [%v]", err)
 	}
 
-	/*	newUserWithValidCIDR, err := DB.Register(cidrslice{"192.168.1.1/32", "invalid"})
-		if err != nil {
-			t.Errorf("Could not create new user with CIDR, got error [%v]", err)
-		}
-	*/
 	for _, test := range []struct {
 		user      string
 		pass      string

--- a/config.cfg
+++ b/config.cfg
@@ -44,6 +44,10 @@ tls_cert_fullchain = "/etc/tls/example.org/fullchain.pem"
 corsorigins = [
     "*"
 ]
+# use HTTP header to get the client ip
+use_header = false
+# header name to pull the ip address / list of ip addresses from
+header_name = "X-Forwarded-For"
 
 [logconfig]
 # logging level: "error", "warning", "info" or "debug"

--- a/dns_test.go
+++ b/dns_test.go
@@ -139,7 +139,7 @@ func TestResolveTXT(t *testing.T) {
 	resolv := resolver{server: "0.0.0.0:15353"}
 	validTXT := "______________valid_response_______________"
 
-	atxt, err := DB.Register()
+	atxt, err := DB.Register(cidrslice{})
 	if err != nil {
 		t.Errorf("Could not initiate db record: [%v]", err)
 		return

--- a/main.go
+++ b/main.go
@@ -49,7 +49,6 @@ func startHTTPAPI() {
 	})
 	api.Use(crs)
 	var ForceAuth = authMiddleware{}
-	api.Get("/register", webRegisterGet)
 	api.Post("/register", webRegisterPost)
 	api.Post("/update", ForceAuth.Serve, webUpdatePost)
 	switch DNSConf.API.TLS {

--- a/main_test.go
+++ b/main_test.go
@@ -68,6 +68,8 @@ func setupConfig() {
 		Port:        "8080",
 		TLS:         "none",
 		CorsOrigins: []string{"*"},
+		UseHeader:   false,
+		HeaderName:  "X-Forwarded-For",
 	}
 
 	var dnscfg = DNSConfig{

--- a/types.go
+++ b/types.go
@@ -66,21 +66,6 @@ type logconfig struct {
 	Format  string `toml:"logformat"`
 }
 
-// ACMETxt is the default structure for the user controlled record
-type ACMETxt struct {
-	Username uuid.UUID
-	Password string
-	ACMETxtPost
-	LastActive int64
-	AllowFrom  string
-}
-
-// ACMETxtPost holds the DNS part of the ACMETxt struct
-type ACMETxtPost struct {
-	Subdomain string `json:"subdomain"`
-	Value     string `json:"txt"`
-}
-
 type acmedb struct {
 	sync.Mutex
 	DB *sql.DB
@@ -88,7 +73,7 @@ type acmedb struct {
 
 type database interface {
 	Init(string, string) error
-	Register() (ACMETxt, error)
+	Register(cidrslice) (ACMETxt, error)
 	GetByUsername(uuid.UUID) (ACMETxt, error)
 	GetByDomain(string) ([]ACMETxt, error)
 	Update(ACMETxt) error

--- a/types.go
+++ b/types.go
@@ -56,6 +56,8 @@ type httpapi struct {
 	TLSCertPrivkey   string `toml:"tls_cert_privkey"`
 	TLSCertFullchain string `toml:"tls_cert_fullchain"`
 	CorsOrigins      []string
+	UseHeader        bool   `toml:"use_header"`
+	HeaderName       string `toml:"header_name"`
 }
 
 // Logging config

--- a/util.go
+++ b/util.go
@@ -2,12 +2,13 @@ package main
 
 import (
 	"crypto/rand"
-	"github.com/BurntSushi/toml"
-	log "github.com/Sirupsen/logrus"
-	"github.com/miekg/dns"
 	"math/big"
 	"regexp"
 	"strings"
+
+	"github.com/BurntSushi/toml"
+	log "github.com/Sirupsen/logrus"
+	"github.com/miekg/dns"
 )
 
 func readConfig(fname string) DNSConfig {
@@ -67,4 +68,15 @@ func startDNS(listen string, proto string) *dns.Server {
 	server := &dns.Server{Addr: listen, Net: proto}
 	go server.ListenAndServe()
 	return server
+}
+
+func getIPListFromHeader(header string) []string {
+	iplist := []string{}
+	for _, v := range strings.Split(header, ",") {
+		if len(v) > 0 {
+			// Ignore empty values
+			iplist = append(iplist, strings.TrimSpace(v))
+		}
+	}
+	return iplist
 }

--- a/util.go
+++ b/util.go
@@ -5,7 +5,6 @@ import (
 	"github.com/BurntSushi/toml"
 	log "github.com/Sirupsen/logrus"
 	"github.com/miekg/dns"
-	"github.com/satori/go.uuid"
 	"math/big"
 	"regexp"
 	"strings"
@@ -43,15 +42,6 @@ func sanitizeDomainQuestion(d string) string {
 		dom = dom[0:firstDot]
 	}
 	return dom
-}
-
-func newACMETxt() ACMETxt {
-	var a = ACMETxt{}
-	password := generatePassword(40)
-	a.Username = uuid.NewV4()
-	a.Password = password
-	a.Subdomain = uuid.NewV4().String()
-	return a
 }
 
 func setupLogging(format string, level string) {

--- a/util_test.go
+++ b/util_test.go
@@ -71,3 +71,27 @@ func TestReadConfig(t *testing.T) {
 		}
 	}
 }
+
+func TestGetIPListFromHeader(t *testing.T) {
+	for i, test := range []struct {
+		input  string
+		output []string
+	}{
+		{"1.1.1.1, 2.2.2.2", []string{"1.1.1.1", "2.2.2.2"}},
+		{" 1.1.1.1 , 2.2.2.2", []string{"1.1.1.1", "2.2.2.2"}},
+		{",1.1.1.1 ,2.2.2.2", []string{"1.1.1.1", "2.2.2.2"}},
+	} {
+		res := getIPListFromHeader(test.input)
+		if len(res) != len(test.output) {
+			t.Errorf("Test %d: Expected [%d] items in return list, but got [%d]", i, len(test.output), len(res))
+		} else {
+
+			for j, vv := range test.output {
+				if res[j] != vv {
+					t.Errorf("Test %d: Expected return value [%v] but got [%v]", j, test.output, res)
+				}
+
+			}
+		}
+	}
+}

--- a/validation.go
+++ b/validation.go
@@ -1,9 +1,10 @@
 package main
 
 import (
+	"unicode/utf8"
+
 	"github.com/satori/go.uuid"
 	"golang.org/x/crypto/bcrypt"
-	"unicode/utf8"
 )
 
 func getValidUsername(u string) (uuid.UUID, error) {

--- a/validation_test.go
+++ b/validation_test.go
@@ -106,3 +106,24 @@ func TestCorrectPassword(t *testing.T) {
 		}
 	}
 }
+
+func TestGetValidCIDRMasks(t *testing.T) {
+	for i, test := range []struct {
+		input  cidrslice
+		output cidrslice
+	}{
+		{cidrslice{"10.0.0.1/24"}, cidrslice{"10.0.0.1/24"}},
+		{cidrslice{"invalid", "127.0.0.1/32"}, cidrslice{"127.0.0.1/32"}},
+	} {
+		ret := test.input.ValidEntries()
+		if len(ret) == len(test.output) {
+			for i, v := range ret {
+				if v != test.output[i] {
+					t.Errorf("Test %d: Expected %q but got %q", i, test.output, ret)
+				}
+			}
+		} else {
+			t.Errorf("Test %d: Expected %q but got %q", i, test.output, ret)
+		}
+	}
+}

--- a/validation_test.go
+++ b/validation_test.go
@@ -114,6 +114,7 @@ func TestGetValidCIDRMasks(t *testing.T) {
 	}{
 		{cidrslice{"10.0.0.1/24"}, cidrslice{"10.0.0.1/24"}},
 		{cidrslice{"invalid", "127.0.0.1/32"}, cidrslice{"127.0.0.1/32"}},
+		{cidrslice{"2002:c0a8::0/32", "8.8.8.8/32"}, cidrslice{"2002:c0a8::0/32", "8.8.8.8/32"}},
 	} {
 		ret := test.input.ValidEntries()
 		if len(ret) == len(test.output) {


### PR DESCRIPTION
- Added new JSON value for registration POST payload to request and response. 
- Removed registration GET endpoint.
- Added new configuration options to define if a header value should be used for the user IP address data (for example X-Forwarded-For, if using reverse proxy)