### PR TITLE
goveralls fixes to get meaninful stats out of coveralls.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,5 @@ before_install:
 script:
   - go vet 
   - golint -set_exit_status
-  - go test -race -v -tags test -covermode=atomic -coverprofile=profile.cov
-  - $HOME/gopath/bin/goveralls -coverprofile=profile.cov -service=travis-ci
+  - go test -race -v
+  - $HOME/gopath/bin/goveralls -ignore main.go -v -service=travis-ci


### PR DESCRIPTION
Ignore main.go, as it's untestable. Only take other files into account to be able to enforce 100% coverage.