### PR TITLE
Fix config not being used

### DIFF
--- a/main.go
+++ b/main.go
@@ -12,7 +12,6 @@ import (
 
 func main() {
 	// Read global config
-	var Config DNSConfig
 	if fileExists("/etc/acme-dns/config.cfg") {
 		Config = readConfig("/etc/acme-dns/config.cfg")
 	} else {


### PR DESCRIPTION
The read-in config was not being used because it was stored in a local variable, not in the global variable with the same name.

This bug was introduced [here](https://github.com/joohoi/acme-dns/commit/9c54da3ee6f89f83dc4e699e7daf2a124eca3a18#diff-7ddfb3e035b42cd70649cc33393fe32cR15).