### PR TITLE
Make autocert use HTTP-01 challenge instead of TLS-SNI

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,8 @@ connection = "acme-dns.db"
 [api]
 # domain name to listen requests for, mandatory if using tls = "letsencrypt"
 api_domain = ""
+# autocert HTTP port, eg. 80 for answering Let's Encrypt HTTP-01 challenges. Mandatory if using tls = "letsencrypt".
+autocert_port = "80"
 # listen port, eg. 443 for default HTTPS
 port = "8080"
 # possible values: "letsencrypt", "cert", "none"
@@ -214,6 +216,7 @@ header_name = "X-Forwarded-For"
 ```
 
 ## Changelog
+- v0.3 Changed autocert to use HTTP-01 challenges, as TLS-SNI is disabled by Let's Encrypt
 - v0.2 Now powered by httprouter, support wildcard certificates, Docker images
 - v0.1 Initial release
 

--- a/config.cfg
+++ b/config.cfg
@@ -36,6 +36,8 @@ connection = "/var/lib/acme-dns/acme-dns.db"
 api_domain = ""
 # listen ip eg. 127.0.0.1
 ip = "0.0.0.0"
+# autocert HTTP port, eg. 80 for answering Let's Encrypt HTTP-01 challenges. Mandatory if using tls = "letsencrypt".
+autocert_port = "80"
 # listen port, eg. 443 for default HTTPS
 port = "80"
 # possible values: "letsencrypt", "cert", "none"

--- a/main.go
+++ b/main.go
@@ -83,6 +83,9 @@ func startHTTPAPI() {
 			Prompt:     autocert.AcceptTOS,
 			HostPolicy: autocert.HostWhitelist(Config.API.Domain),
 		}
+		autocerthost := Config.API.IP + ":" + Config.API.AutocertPort
+		log.WithFields(log.Fields{"autocerthost": autocerthost, "domain": Config.API.Domain}).Debug("Opening HTTP port for autocert")
+		go http.ListenAndServe(autocerthost, m.HTTPHandler(nil))
 		cfg.GetCertificate = m.GetCertificate
 		srv := &http.Server{
 			Addr:      host,
@@ -90,7 +93,7 @@ func startHTTPAPI() {
 			TLSConfig: cfg,
 			ErrorLog:  stdlog.New(logwriter, "", 0),
 		}
-		log.WithFields(log.Fields{"host": host, "domain": Config.API.Domain}).Info("Listening HTTPS autocert")
+		log.WithFields(log.Fields{"host": host, "domain": Config.API.Domain}).Info("Listening HTTPS, using certificate from autocert")
 		log.Fatal(srv.ListenAndServeTLS("", ""))
 	case "cert":
 		srv := &http.Server{

--- a/types.go
+++ b/types.go
@@ -52,6 +52,7 @@ type dbsettings struct {
 type httpapi struct {
 	Domain           string `toml:"api_domain"`
 	IP               string
+	AutocertPort     string `toml:"autocert_port"`
 	Port             string `toml:"port"`
 	TLS              string
 	TLSCertPrivkey   string `toml:"tls_cert_privkey"`


### PR DESCRIPTION
TLS-SNI challenge has been disabled by Let's Encrypt, so we need to use another challenge type to automatically acquire a certificate. This PR changes the autocert challenge to HTTP-01.

Fixes: #35 