### PR TITLE
install ca-certificates package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ COPY --from=builder /go/src/github.com/joohoi/acme-dns .
 RUN mkdir -p /etc/acme-dns
 RUN mkdir -p /var/lib/acme-dns
 RUN rm -rf ./config.cfg
+RUN apk --no-cache add ca-certificates && update-ca-certificates
 
 VOLUME ["/etc/acme-dns", "/var/lib/acme-dns"]
 ENTRYPOINT ["./acme-dns"]


### PR DESCRIPTION
package ca-certificates is not installed by default on alpine.. this fixes the following error when using autocert.
`
01/02/2018 9:02:53 pmINFO[0020] http: TLS handshake error from X.X.X.X:48846: Get https://acme-v01.api.letsencrypt.org/directory: x509: failed to load system roots and no roots provided
`
