### PR TITLE
README: simplify installation instructions with `go get`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Check out how in the INSTALL section.
 
 1) Install [Go 1.9 or newer](https://golang.org/doc/install)
 
-2) Install acme-dns: `go get https://github.com/joohoi/acme-dns/...`
+2) Install acme-dns: `go get github.com/joohoi/acme-dns/...`
 
 3) Edit config.cfg to suit your needs (see [configuration](#configuration)). `acme-dns` will read the configuration file from `/etc/acme-dns/config.cfg` or `./config.cfg`
 

--- a/README.md
+++ b/README.md
@@ -110,13 +110,11 @@ Check out how in the INSTALL section.
 
 1) Install [Go 1.9 or newer](https://golang.org/doc/install)
 
-2) Clone this repo: `git clone https://github.com/joohoi/acme-dns $GOPATH/src/acme-dns`
+2) Install acme-dns: `go get https://github.com/joohoi/acme-dns/...`
 
-3) Build ACME-DNS: `go build`
+3) Edit config.cfg to suit your needs (see [configuration](#configuration))
 
-4) Edit config.cfg to suit your needs (see [configuration](#configuration))
-
-5) Run acme-dns. Please note that acme-dns needs to open a privileged port (53, domain), so it needs to be run with elevated privileges.
+4) Run acme-dns. Please note that acme-dns needs to open a privileged port (53, domain), so it needs to be run with elevated privileges.
 
 ## Using Docker
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Check out how in the INSTALL section.
 
 2) Install acme-dns: `go get https://github.com/joohoi/acme-dns/...`
 
-3) Edit config.cfg to suit your needs (see [configuration](#configuration))
+3) Edit config.cfg to suit your needs (see [configuration](#configuration)). `acme-dns` will read the configuration file from `/etc/acme-dns/config.cfg` or `./config.cfg`
 
 4) Run acme-dns. Please note that acme-dns needs to open a privileged port (53, domain), so it needs to be run with elevated privileges.
 


### PR DESCRIPTION
Prior to this commit the installation instructions in the README had you
use `git clone` and then `go build`. This can be collapsed into one step
using a more idiomatic `go get` command. This commit updates the README
accordingly.

Edit: I also snuck in a commit ( 670ed03 ) to document the two locations a
config file can be placed. Happy to split this off into a separate PR if preferred.