### PR TITLE
README: Add example 'ip' in example API config.

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,8 @@ connection = "acme-dns.db"
 api_domain = ""
 # autocert HTTP port, eg. 80 for answering Let's Encrypt HTTP-01 challenges. Mandatory if using tls = "letsencrypt".
 autocert_port = "80"
+# listen ip, default "" listens on all interfaces/addresses
+ip = "127.0.0.1"
 # listen port, eg. 443 for default HTTPS
 port = "8080"
 # possible values: "letsencrypt", "cert", "none"


### PR DESCRIPTION
`acme-dns` supports binding the API to a specific interface instead of
all interfaces by providing an `ip` address in the `[api]` configuration
section. Prior to this commit the `ip` field wasn't shown in the example
configuration in the README. This commit adds an example showing how to
configure `acme-dns` to listen only on `127.0.0.1` to the example config
and describes what the default value (`""`) does.