### PR TITLE
Properly parse r.RemoteAddr

### DIFF
--- a/acmetxt.go
+++ b/acmetxt.go
@@ -33,9 +33,9 @@ func (c *cidrslice) JSON() string {
 func (c *cidrslice) ValidEntries() []string {
 	valid := []string{}
 	for _, v := range *c {
-		_, _, err := net.ParseCIDR(v)
+		_, _, err := net.ParseCIDR(sanitizeIPv6addr(v))
 		if err == nil {
-			valid = append(valid, v)
+			valid = append(valid, sanitizeIPv6addr(v))
 		}
 	}
 	return valid

--- a/auth.go
+++ b/auth.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 
 	"github.com/julienschmidt/httprouter"
@@ -83,5 +84,10 @@ func updateAllowedFromIP(r *http.Request, user ACMETxt) bool {
 		ips := getIPListFromHeader(r.Header.Get(Config.API.HeaderName))
 		return user.allowedFromList(ips)
 	}
-	return user.allowedFrom(r.RemoteAddr)
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		log.WithFields(log.Fields{"error": err.Error(), "remoteaddr": r.RemoteAddr}).Error("Error while parsing remote address")
+		host = ""
+	}
+	return user.allowedFrom(host)
 }

--- a/auth_test.go
+++ b/auth_test.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestUpdateAllowedFromIP(t *testing.T) {
+	userWithAllow := newACMETxt()
+	userWithAllow.AllowFrom = cidrslice{"192.168.1.2/32", "[::1]/128"}
+	userWithoutAllow := newACMETxt()
+
+	for i, test := range []struct {
+		remoteaddr string
+		expected   bool
+	}{
+		{"192.168.1.2:1234", true},
+		{"192.168.1.1:1234", false},
+		{"invalid", false},
+		{"[::1]:4567", true},
+	} {
+		newreq, _ := http.NewRequest("GET", "/whatever", nil)
+		newreq.RemoteAddr = test.remoteaddr
+		ret := updateAllowedFromIP(newreq, userWithAllow)
+		if test.expected != ret {
+			t.Errorf("Test %d: Unexpected result for user with allowForm set", i)
+		}
+
+		if !updateAllowedFromIP(newreq, userWithoutAllow) {
+			t.Errorf("Test %d: Unexpected result for user without allowForm set", i)
+		}
+	}
+}

--- a/util.go
+++ b/util.go
@@ -38,6 +38,12 @@ func sanitizeString(s string) string {
 	return re.ReplaceAllString(s, "")
 }
 
+func sanitizeIPv6addr(s string) string {
+	// Remove brackets from IPv6 addresses, net.ParseCIDR needs this
+	re, _ := regexp.Compile("[\\[\\]]+")
+	return re.ReplaceAllString(s, "")
+}
+
 func generatePassword(length int) string {
 	ret := make([]byte, length)
 	const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890-_"


### PR DESCRIPTION
RemoteAddr in `http.Request` is in form of HOST:PORT, so the value needed to be split before comparing to the CIDR masks in validation code.

Fixes: #45 