### PR TITLE
README: Add goacmedns, a Go acme-dns client library

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@ header_name = "X-Forwarded-For"
 ### Libraries
 
 - Generic client library in Python ([PyPI](https://pypi.python.org/pypi/pyacmedns/)): [https://github.com/joohoi/pyacmedns](https://github.com/joohoi/pyacmedns)
+- Generic client library in Go: [https://github.com/cpu/goacmedns](https://github.com/cpu/goacmedns)
 
 
 ## Changelog


### PR DESCRIPTION
:wave: Hi @joohoi,

In the process of writing an ACME-DNS hook for a Go ACME client (`github.com/xenolf/lego`) I ported your `pyacmedns` library to Go: https://github.com/cpu/goacmedns

This PR adds a link to the README next to `pyacmedns`. I hope someone finds it useful!