### PR TITLE
README: Add Lego to supported clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,9 +284,9 @@ header_name = "X-Forwarded-For"
 ## Clients
 
 - acme.sh: [https://github.com/Neilpang/acme.sh](https://github.com/Neilpang/acme.sh)
+- Lego: [https://github.com/xenolf/lego](https://github.com/xenolf/lego)
 - Posh-ACME: [https://github.com/rmbolger/Posh-ACME](https://github.com/rmbolger/Posh-ACME)
 - Sewer: [https://github.com/komuw/sewer](https://github.com/komuw/sewer)
-- Lego: [https://github.com/xenolf/lego](https://github.com/xenolf/lego)
 
 ### Authentication hooks
 

--- a/README.md
+++ b/README.md
@@ -286,6 +286,7 @@ header_name = "X-Forwarded-For"
 - acme.sh: [https://github.com/Neilpang/acme.sh](https://github.com/Neilpang/acme.sh)
 - Posh-ACME: [https://github.com/rmbolger/Posh-ACME](https://github.com/rmbolger/Posh-ACME)
 - Sewer: [https://github.com/komuw/sewer](https://github.com/komuw/sewer)
+- Lego: [https://github.com/xenolf/lego](https://github.com/xenolf/lego)
 
 ### Authentication hooks
 


### PR DESCRIPTION
The [Lego ACME client/library](https://github.com/xenolf/lego) supports ACME-DNS as of https://github.com/xenolf/lego/commit/04e2d74406d42a3727e7a132c1a39735ac527f51 :tada:

