### PR TITLE
Added supplementary error checking

### DIFF
--- a/main.go
+++ b/main.go
@@ -16,16 +16,16 @@ import (
 
 func main() {
 	// Read global config
-	if isFileAccessible("/etc/acme-dns/config.cfg") {
+	if fileIsAccessible("/etc/acme-dns/config.cfg") {
 		log.WithFields(log.Fields{"file": "/etc/acme-dns/config.cfg"}).Info("Using config file")
 		Config = readConfig("/etc/acme-dns/config.cfg")
 
-	} else if isFileAccessible("./config.cfg") {
+	} else if fileIsAccessible("./config.cfg") {
 		log.WithFields(log.Fields{"file": "./config.cfg"}).Info("Using config file")
 		Config = readConfig("./config.cfg")
 	} else {
-	       log.Errorf("Configuration file not found")
-	       os.Exit(1)
+		log.Errorf("Configuration file not found")
+		os.Exit(1)
 	}
 
 	setupLogging(Config.Logconfig.Format, Config.Logconfig.Level)

--- a/main.go
+++ b/main.go
@@ -17,12 +17,15 @@ import (
 func main() {
 	// Read global config
 	if fileExists("/etc/acme-dns/config.cfg") {
-		Config = readConfig("/etc/acme-dns/config.cfg")
 		log.WithFields(log.Fields{"file": "/etc/acme-dns/config.cfg"}).Info("Using config file")
+		Config = readConfig("/etc/acme-dns/config.cfg")
 
-	} else {
+	} else if fileExists("./config.cfg") {
 		log.WithFields(log.Fields{"file": "./config.cfg"}).Info("Using config file")
-		Config = readConfig("config.cfg")
+		Config = readConfig("./config.cfg")
+	} else {
+	       log.Error("Configuration file not found")
+	       os.Exit(1)
 	}
 
 	setupLogging(Config.Logconfig.Format, Config.Logconfig.Level)

--- a/main.go
+++ b/main.go
@@ -16,15 +16,15 @@ import (
 
 func main() {
 	// Read global config
-	if fileExists("/etc/acme-dns/config.cfg") {
+	if isFileAccessible("/etc/acme-dns/config.cfg") {
 		log.WithFields(log.Fields{"file": "/etc/acme-dns/config.cfg"}).Info("Using config file")
 		Config = readConfig("/etc/acme-dns/config.cfg")
 
-	} else if fileExists("./config.cfg") {
+	} else if isFileAccessible("./config.cfg") {
 		log.WithFields(log.Fields{"file": "./config.cfg"}).Info("Using config file")
 		Config = readConfig("./config.cfg")
 	} else {
-	       log.Error("Configuration file not found")
+	       log.Errorf("Configuration file not found")
 	       os.Exit(1)
 	}
 

--- a/util.go
+++ b/util.go
@@ -35,8 +35,8 @@ func fileExists(fname string) bool {
 	return true
 }
 
-func isFileAccessible(fname string) bool {
-	return  fileExists(fname) && isFileReadable(fname)
+func fileIsAccessible(fname string) bool {
+	return fileExists(fname) && isFileReadable(fname)
 }
 
 func readConfig(fname string) DNSConfig {
@@ -45,7 +45,7 @@ func readConfig(fname string) DNSConfig {
 	// but will if there is an error in the config file
 	_, err := toml.DecodeFile(fname, &conf)
 	if err != nil {
-		log.Error("Error decoding configuration file [%v]", err)
+		log.Errorf("Error decoding configuration file [%v]", err)
 		os.Exit(1)
 	}
 	return conf

--- a/util.go
+++ b/util.go
@@ -18,18 +18,30 @@ func jsonError(message string) []byte {
 }
 
 func fileExists(fname string) bool {
-	_, err := os.Stat(fname)
-	if err != nil {
-		return false
-	}
-	return true
+        _, err := os.Stat(fname)
+        if err != nil {
+                return false
+        }
+        // file exists but might not be readable
+        f, err := os.Open(fname)
+        if err != nil {
+                log.Error("Cannot open file : [%v]", err)
+                os.Exit(1)
+        }
+f.Close()
+        return true
 }
 
 func readConfig(fname string) DNSConfig {
-	var conf DNSConfig
-	// Practically never errors
-	_, _ = toml.DecodeFile(fname, &conf)
-	return conf
+        var conf DNSConfig
+        // Practically never errors
+        // but will if there is an error in the config file
+        _, err := toml.DecodeFile(fname, &conf)
+        if err != nil {
+                log.Error("Error decoding configuration file [%v]", err)
+                os.Exit(1)
+        }
+        return conf
 }
 
 func sanitizeString(s string) string {

--- a/util.go
+++ b/util.go
@@ -18,30 +18,30 @@ func jsonError(message string) []byte {
 }
 
 func fileExists(fname string) bool {
-        _, err := os.Stat(fname)
-        if err != nil {
-                return false
-        }
-        // file exists but might not be readable
-        f, err := os.Open(fname)
-        if err != nil {
-                log.Error("Cannot open file : [%v]", err)
-                os.Exit(1)
-        }
-f.Close()
-        return true
+	_, err := os.Stat(fname)
+	if err != nil {
+		return false
+	}
+	// file exists but might not be readable
+	f, err := os.Open(fname)
+	if err != nil {
+		log.Error("Cannot open file : [%v]", err)
+		os.Exit(1)
+	}
+	f.Close()
+	return true
 }
 
 func readConfig(fname string) DNSConfig {
-        var conf DNSConfig
-        // Practically never errors
-        // but will if there is an error in the config file
-        _, err := toml.DecodeFile(fname, &conf)
-        if err != nil {
-                log.Error("Error decoding configuration file [%v]", err)
-                os.Exit(1)
-        }
-        return conf
+	var conf DNSConfig
+	// Practically never errors
+	// but will if there is an error in the config file
+	_, err := toml.DecodeFile(fname, &conf)
+	if err != nil {
+		log.Error("Error decoding configuration file [%v]", err)
+		os.Exit(1)
+	}
+	return conf
 }
 
 func sanitizeString(s string) string {

--- a/util.go
+++ b/util.go
@@ -17,19 +17,26 @@ func jsonError(message string) []byte {
 	return []byte(fmt.Sprintf("{\"error\": \"%s\"}", message))
 }
 
+func isFileReadable(fname string) bool {
+	f, err := os.Open(fname)
+	if err != nil {
+		log.Errorf("Cannot open file : [%v]", err)
+		os.Exit(1)
+	}
+	f.Close()
+	return true
+}
+
 func fileExists(fname string) bool {
 	_, err := os.Stat(fname)
 	if err != nil {
 		return false
 	}
-	// file exists but might not be readable
-	f, err := os.Open(fname)
-	if err != nil {
-		log.Error("Cannot open file : [%v]", err)
-		os.Exit(1)
-	}
-	f.Close()
 	return true
+}
+
+func isFileAccessible(fname string) bool {
+	return  fileExists(fname) && isFileReadable(fname)
 }
 
 func readConfig(fname string) DNSConfig {


### PR DESCRIPTION
Added some additional error checking:

1) In util.go, checking for errors in the tom.DecodeFile call (func ReadConfig). DecodeFile itself may rarely return an error but will if the config.cfg file has errors, e.g. missing quotes. If errors are not checked at this point, readConfig returns an invalid configuration that will generate an error in main.go showing up as an empty driver since the Config.Database.Engine string will be empty which is misleading as the cause of the problem.
2) Modified fileExists in util.go to ensure that the file can be read and not only exists. The file may "exist" but have the wrong permissions. There might be a more elegant way than using Open.
3) Added more explicit checks for the existence of the configuration file in main.go