### PR TITLE
Better error messages for missing DB config values

### DIFF
--- a/util.go
+++ b/util.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"crypto/rand"
+	"errors"
 	"fmt"
 	"math/big"
 	"os"
@@ -33,7 +34,22 @@ func fileIsAccessible(fname string) bool {
 func readConfig(fname string) (DNSConfig, error) {
 	var conf DNSConfig
 	_, err := toml.DecodeFile(fname, &conf)
-	return conf, err
+	if err != nil {
+		// Return with config file parsing errors from toml package
+		return conf, err
+	}
+	return prepareConfig(conf)
+}
+
+// prepareConfig checks that mandatory values exist, and can be used to set default values in the future
+func prepareConfig(conf DNSConfig) (DNSConfig, error) {
+	if conf.Database.Engine == "" {
+		return conf, errors.New("Missing database configuration option \"engine\".")
+	}
+	if conf.Database.Connection == "" {
+		return conf, errors.New("Missing database configuration option \"connection\".")
+	}
+	return conf, nil
 }
 
 func sanitizeString(s string) string {

--- a/util.go
+++ b/util.go
@@ -44,10 +44,10 @@ func readConfig(fname string) (DNSConfig, error) {
 // prepareConfig checks that mandatory values exist, and can be used to set default values in the future
 func prepareConfig(conf DNSConfig) (DNSConfig, error) {
 	if conf.Database.Engine == "" {
-		return conf, errors.New("Missing database configuration option \"engine\".")
+		return conf, errors.New("missing database configuration option \"engine\"")
 	}
 	if conf.Database.Connection == "" {
-		return conf, errors.New("Missing database configuration option \"connection\".")
+		return conf, errors.New("missing database configuration option \"connection\"")
 	}
 	return conf, nil
 }

--- a/util_test.go
+++ b/util_test.go
@@ -127,3 +127,25 @@ func TestFileCheckOK(t *testing.T) {
 		t.Errorf("File should be accessible")
 	}
 }
+
+func TestPrepareConfig(t *testing.T) {
+	for i, test := range []struct {
+		input       DNSConfig
+		shoulderror bool
+	}{
+		{DNSConfig{Database: dbsettings{Engine: "whatever", Connection: "whatever_too"}}, false},
+		{DNSConfig{Database: dbsettings{Engine: "", Connection: "whatever_too"}}, true},
+		{DNSConfig{Database: dbsettings{Engine: "whatever", Connection: ""}}, true},
+	} {
+		_, err := prepareConfig(test.input)
+		if test.shoulderror {
+			if err == nil {
+				t.Errorf("Test %d: Expected error with prepareConfig input data [%v]", i, test.input)
+			}
+		} else {
+			if err != nil {
+				t.Errorf("Test %d: Expected no error with prepareConfig input data [%v]", i, test.input)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Prior to this PR, if database configuration values are missing, acme-dns errors with confusing error messages from `database/sql` like:
```
ERRO[0000] Could not open database [sql: unknown driver "" (forgotten import?)]
```
