### PR TITLE
Cmd line flag `-c` for config location

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ See the INSTALL section for information on how to do this.
 
 2) Install acme-dns: `go get github.com/joohoi/acme-dns/...`. This will install acme-dns to `~/go/bin/acme-dns`.
 
-3) Edit config.cfg to suit your needs (see [configuration](#configuration)). `acme-dns` will read the configuration file from `/etc/acme-dns/config.cfg` or `./config.cfg`.
+3) Edit config.cfg to suit your needs (see [configuration](#configuration)). `acme-dns` will read the configuration file from `/etc/acme-dns/config.cfg` or `./config.cfg`, or a location specified with the `-c` flag.
 
 4) If your system has systemd, you can optionally install acme-dns as a service so that it will start on boot and be tracked by systemd. This also allows us to add the `CAP_NET_BIND_SERVICE` capability so that acme-dns can be run by a user other than root.
 
@@ -300,6 +300,9 @@ header_name = "X-Forwarded-For"
 
 
 ## Changelog
+- unreleased
+   - New
+      - Command line flag `-c` to specify location of config file.
 - v0.5
    - New
       - Configurable certificate cache directory

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"crypto/tls"
+	"flag"
 	stdlog "log"
 	"net/http"
 	"os"
@@ -18,11 +19,13 @@ import (
 func main() {
 	// Created files are not world writable
 	syscall.Umask(0077)
+	configPtr := flag.String("c", "/etc/acme-dns/config.cfg", "config file location")
+	flag.Parse()
 	// Read global config
 	var err error
-	if fileIsAccessible("/etc/acme-dns/config.cfg") {
-		log.WithFields(log.Fields{"file": "/etc/acme-dns/config.cfg"}).Info("Using config file")
-		Config, err = readConfig("/etc/acme-dns/config.cfg")
+	if fileIsAccessible(*configPtr) {
+		log.WithFields(log.Fields{"file": *configPtr}).Info("Using config file")
+		Config, err = readConfig(*configPtr)
 	} else if fileIsAccessible("./config.cfg") {
 		log.WithFields(log.Fields{"file": "./config.cfg"}).Info("Using config file")
 		Config, err = readConfig("./config.cfg")


### PR DESCRIPTION
Add command line parsing and a flag `-c` to specify where the config
file should be loaded from.