### PR TITLE
Make registration endpoint URI configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,9 @@ header_name = "X-Forwarded-For"
 
 
 ## Changelog
+- unreleased
+   - New
+      - Registration URI configurable
 - v0.5
    - New
       - Configurable certificate cache directory

--- a/config.cfg
+++ b/config.cfg
@@ -38,6 +38,8 @@ api_domain = ""
 ip = "0.0.0.0"
 # disable registration endpoint
 disable_registration = false
+# endpoint URI for registration
+#registration_uri = "/register"
 # autocert HTTP port, eg. 80 for answering Let's Encrypt HTTP-01 challenges. Mandatory if using tls = "letsencrypt".
 autocert_port = "80"
 # listen port, eg. 443 for default HTTPS

--- a/main.go
+++ b/main.go
@@ -78,7 +78,12 @@ func startHTTPAPI() {
 		c.Log = stdlog.New(logwriter, "", 0)
 	}
 	if !Config.API.DisableRegistration {
-		api.POST("/register", webRegisterPost)
+		uri := Config.API.RegistrationUri
+		if (uri == "") {
+		    uri = "/register"
+		}
+		log.WithFields(log.Fields{"register_uri": uri}).Debug("Register endpoint")
+		api.POST(uri, webRegisterPost)
 	}
 	api.POST("/update", Auth(webUpdatePost))
 

--- a/types.go
+++ b/types.go
@@ -54,6 +54,7 @@ type httpapi struct {
 	Domain              string `toml:"api_domain"`
 	IP                  string
 	DisableRegistration bool   `toml:"disable_registration"`
+	RegistrationUri     string `toml:"registration_uri"`
 	AutocertPort        string `toml:"autocert_port"`
 	Port                string `toml:"port"`
 	TLS                 string


### PR DESCRIPTION
This allows hiding the registration while leaving it enabled and
exposed to the wider network.