### PR TITLE
README: use absolute path for sqlite DB in example config

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ debug = false
 # Database engine to use, sqlite3 or postgres
 engine = "sqlite3"
 # Connection string, filename for sqlite3 and postgres://$username:$password@$host/$db_name for postgres
-connection = "acme-dns.db"
+connection = "/var/lib/acme-dns/acme-dns.db"
 # connection = "postgres://user:password@localhost/acmedns_db"
 
 [api]


### PR DESCRIPTION
This PR changes the example config in the README to use an absolute path for the sqlite DB, like in the `config.cfg`.

Currently the example config would create a new DB in the current working directory. This might be intended (for testing purposes), but then should be documented accordingly so that the user changes the current working directory accordingly first.