### PR TITLE
Better error handling in goroutines

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: go
 go:
   - 1.9
+  - 1.11
 env:
   - "PATH=/home/travis/gopath/bin:$PATH"
 before_install:

--- a/README.md
+++ b/README.md
@@ -212,7 +212,9 @@ $ dig @auth.example.org d420c923-bbd7-4056-ab64-c3ca54c9b3cf.auth.example.org
 
 ```bash
 [general]
-# dns interface
+# DNS interface. Note that systemd-resolved may reserve port 53 on 127.0.0.53
+# In this case acme-dns will error out and you will need to define the listening interface
+# for example: listen = "127.0.0.1:53"
 listen = ":53"
 # protocol, "udp", "udp4", "udp6" or "tcp", "tcp4", "tcp6"
 protocol = "udp"

--- a/config.cfg
+++ b/config.cfg
@@ -1,5 +1,7 @@
 [general]
-# dns interface
+# DNS interface. Note that systemd-resolved may reserve port 53 on 127.0.0.53
+# In this case acme-dns will error out and you will need to define the listening interface
+# for example: listen = "127.0.0.1:53"
 listen = ":53"
 # protocol, "udp", "udp4", "udp6" or "tcp", "tcp4", "tcp6"
 protocol = "udp"

--- a/main.go
+++ b/main.go
@@ -79,8 +79,7 @@ func main() {
 func startDNS(server *dns.Server, errChan chan error) {
 	// DNS server part
 	dns.HandleFunc(".", handleRequest)
-	host := Config.General.Listen + ":" + Config.General.Proto
-	log.WithFields(log.Fields{"host": host}).Info("Listening DNS")
+	log.WithFields(log.Fields{"addr": Config.General.Listen}).Info("Listening DNS")
 	err := server.ListenAndServe()
 	if err != nil {
 		errChan <- err

--- a/main_test.go
+++ b/main_test.go
@@ -42,7 +42,8 @@ func TestMain(m *testing.M) {
 		_ = newDb.Init("sqlite3", ":memory:")
 	}
 	DB = newDb
-	server := startDNS("0.0.0.0:15353", "udp")
+	server := setupDNSServer()
+	go startDNS(server, make(chan error, 1))
 	exitval := m.Run()
 	server.Shutdown()
 	DB.Close()
@@ -57,6 +58,8 @@ func setupConfig() {
 
 	var generalcfg = general{
 		Domain:        "auth.example.org",
+		Listen:        "127.0.0.1:15553",
+		Proto:         "udp",
 		Nsname:        "ns1.auth.example.org",
 		Nsadmin:       "admin.example.org",
 		StaticRecords: records,

--- a/util.go
+++ b/util.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/BurntSushi/toml"
-	"github.com/miekg/dns"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -106,14 +105,6 @@ func setupLogging(format string, level string) {
 		log.SetLevel(log.ErrorLevel)
 	}
 	// TODO: file logging
-}
-
-func startDNS(listen string, proto string) *dns.Server {
-	// DNS server part
-	dns.HandleFunc(".", handleRequest)
-	server := &dns.Server{Addr: listen, Net: proto}
-	go server.ListenAndServe()
-	return server
 }
 
 func getIPListFromHeader(header string) []string {


### PR DESCRIPTION
This PR adds a error handling mechanism to spawned goroutines using channels. This allows printing error messages when spawning DNS server goroutine if it encounters an error.

Fixes: #118