### PR TITLE
Fix Docker instructions and add option to bind both DNS to both UDP and TCP

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,3 +19,4 @@ RUN apk --no-cache add ca-certificates && update-ca-certificates
 VOLUME ["/etc/acme-dns", "/var/lib/acme-dns"]
 ENTRYPOINT ["./acme-dns"]
 EXPOSE 53 80 443
+EXPOSE 53/udp

--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ See the INSTALL section for information on how to do this.
 ```
 docker run --rm --name acmedns                 \
  -p 53:53                                      \
+ -p 53:53/udp                                  \
  -p 80:80                                      \
  -v /path/to/your/config:/etc/acme-dns:ro      \
  -v /path/to/your/data:/var/lib/acme-dns       \
@@ -216,8 +217,8 @@ $ dig @auth.example.org d420c923-bbd7-4056-ab64-c3ca54c9b3cf.auth.example.org
 # In this case acme-dns will error out and you will need to define the listening interface
 # for example: listen = "127.0.0.1:53"
 listen = ":53"
-# protocol, "udp", "udp4", "udp6" or "tcp", "tcp4", "tcp6"
-protocol = "udp"
+# protocol, "both", "both4", "both6", "udp", "udp4", "udp6" or "tcp", "tcp4", "tcp6"
+protocol = "both"
 # domain name to serve the requests off of
 domain = "auth.example.org"
 # zone name server
@@ -300,6 +301,10 @@ logformat = "text"
 
 
 ## Changelog
+
+- master
+   - Changed
+      - A new protocol selection for DNS server "both", that binds both - UDP and TCP ports.
 - v0.6
    - New
       - Command line flag `-c` to specify location of config file.

--- a/config.cfg
+++ b/config.cfg
@@ -2,9 +2,9 @@
 # DNS interface. Note that systemd-resolved may reserve port 53 on 127.0.0.53
 # In this case acme-dns will error out and you will need to define the listening interface
 # for example: listen = "127.0.0.1:53"
-listen = ":53"
-# protocol, "udp", "udp4", "udp6" or "tcp", "tcp4", "tcp6"
-protocol = "udp"
+listen = "127.0.0.1:53"
+# protocol, "both", "both4", "both6", "udp", "udp4", "udp6" or "tcp", "tcp4", "tcp6"
+protocol = "both"
 # domain name to serve the requests off of
 domain = "auth.example.org"
 # zone name server
@@ -26,7 +26,8 @@ debug = false
 engine = "sqlite3"
 # Connection string, filename for sqlite3 and postgres://$username:$password@$host/$db_name for postgres
 # Please note that the default Docker image uses path /var/lib/acme-dns/acme-dns.db for sqlite3
-connection = "/var/lib/acme-dns/acme-dns.db"
+#connection = "/var/lib/acme-dns/acme-dns.db"
+connection = "acme-dns.db"
 # connection = "postgres://user:password@localhost/acmedns_db"
 
 [api]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
     ports:
       - "443:443"
       - "53:53"
+      - "53:53/udp"
       - "80:80"
     volumes:
       - ./config:/etc/acme-dns:ro

--- a/main_test.go
+++ b/main_test.go
@@ -43,7 +43,7 @@ func TestMain(m *testing.M) {
 		_ = newDb.Init("sqlite3", ":memory:")
 	}
 	DB = newDb
-	server := setupDNSServer()
+	server := setupDNSServer("udp")
 	// Make sure that we're not creating a race condition in tests
 	var wg sync.WaitGroup
 	wg.Add(1)


### PR DESCRIPTION
Fixes the Docker documentation, provided `docker-compose.yml` and adds the config option (also the new default) to bind DNS listener to both - UDP and TCP ports.

Fixes: #129 
Fixes: #80 