### PR TITLE
Fix responses to be more standards compliant

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,10 +326,12 @@ logformat = "text"
 ## Changelog
 
 - master
-   - Unreleased
-      - Added new endpoint to perform health checks
+   - Added
+      - New endpoint to perform health checks
    - Changed
       - A new protocol selection for DNS server "both", that binds both - UDP and TCP ports.
+      - Refactored DNS server internals.
+      - Handle some aspects of DNS spec better.
 - v0.6
    - New
       - Command line flag `-c` to specify location of config file.

--- a/dns.go
+++ b/dns.go
@@ -146,7 +146,7 @@ func (d *DNSServer) isAuthoritative(q dns.Question) bool {
 		return true
 	}
 	domainParts := strings.Split(q.Name, ".")
-	for i, _ := range domainParts {
+	for i := range domainParts {
 		if d.answeringForDomain(strings.Join(domainParts[i:], ".")) {
 			return true
 		}


### PR DESCRIPTION
This PR adds correct handling for:
 - EDNS requests, by indicating that EDNS isn't implemented: FORMERRsome 
 - Figure out if some of the parent domains exists in case of NXDOMAIN and set authoritative bit and append SOA record for caching.
 - If other than requested records exist for domain, return an empty NOERROR response.

Fixes #127 