### PR TITLE
SOA for authoritative NXDOMAIN response should be in the Authoritative section

### DIFF
--- a/dns.go
+++ b/dns.go
@@ -104,7 +104,7 @@ func (d *DNSServer) readQuery(m *dns.Msg) {
 	m.MsgHdr.Authoritative = authoritative
 	if authoritative {
 		if m.MsgHdr.Rcode == dns.RcodeNameError {
-			m.Answer = append(m.Answer, d.SOA)
+			m.Ns = append(m.Ns, d.SOA)
 		}
 	}
 

--- a/dns_test.go
+++ b/dns_test.go
@@ -140,11 +140,11 @@ func TestAuthoritative(t *testing.T) {
 	if answer.Rcode != dns.RcodeNameError {
 		t.Errorf("Was expecing NXDOMAIN rcode, but got [%s] instead.", dns.RcodeToString[answer.Rcode])
 	}
-	if len(answer.Answer) != 1 {
-		t.Errorf("Was expecting exactly one answer (SOA) for invalid subdomain, but got %d", len(answer.Answer))
+	if len(answer.Ns) != 1 {
+		t.Errorf("Was expecting exactly one answer (SOA) for invalid subdomain, but got %d", len(answer.Ns))
 	}
-	if answer.Answer[0].Header().Rrtype != dns.TypeSOA {
-		t.Errorf("Was expecting SOA record as answer for NXDOMAIN but got [%s]", dns.TypeToString[answer.Answer[0].Header().Rrtype])
+	if answer.Ns[0].Header().Rrtype != dns.TypeSOA {
+		t.Errorf("Was expecting SOA record as answer for NXDOMAIN but got [%s]", dns.TypeToString[answer.Ns[0].Header().Rrtype])
 	}
 	if !answer.MsgHdr.Authoritative {
 		t.Errorf("Was expecting authoritative bit to be set")


### PR DESCRIPTION
When appending the SOA for authoritative NXDOMAIN responses, it needs to go in the Authoritative section, not the Answer section.

This fixes acme-dns validation for the lego Let's Encrypt client.

This issue was identified in [lego issue 707](https://github.com/xenolf/lego/issues/707) and almost fixed in [acme-dns issue 127](https://github.com/joohoi/acme-dns/issues/127).