### PR TITLE
Respond case insensitively to A and SOA requests

### DIFF
--- a/dns.go
+++ b/dns.go
@@ -113,7 +113,7 @@ func (d *DNSServer) readQuery(m *dns.Msg) {
 func (d *DNSServer) getRecord(q dns.Question) ([]dns.RR, error) {
 	var rr []dns.RR
 	var cnames []dns.RR
-	domain, ok := d.Domains[q.Name]
+	domain, ok := d.Domains[strings.ToLower(q.Name)]
 	if !ok {
 		return rr, fmt.Errorf("No records for domain %s", q.Name)
 	}
@@ -133,7 +133,7 @@ func (d *DNSServer) getRecord(q dns.Question) ([]dns.RR, error) {
 
 // answeringForDomain checks if we have any records for a domain
 func (d *DNSServer) answeringForDomain(name string) bool {
-	_, ok := d.Domains[name]
+	_, ok := d.Domains[strings.ToLower(name)]
 	return ok
 }
 
@@ -141,7 +141,7 @@ func (d *DNSServer) isAuthoritative(q dns.Question) bool {
 	if d.answeringForDomain(q.Name) {
 		return true
 	}
-	domainParts := strings.Split(q.Name, ".")
+	domainParts := strings.Split(strings.ToLower(q.Name), ".")
 	for i := range domainParts {
 		if d.answeringForDomain(strings.Join(domainParts[i:], ".")) {
 			return true

--- a/dns.go
+++ b/dns.go
@@ -104,7 +104,7 @@ func (d *DNSServer) readQuery(m *dns.Msg) {
 	m.MsgHdr.Authoritative = authoritative
 	if authoritative {
 		if m.MsgHdr.Rcode == dns.RcodeNameError {
-			m.Answer = append(m.Answer, d.SOA)
+			m.Ns = append(m.Ns, d.SOA)
 		}
 	}
 

--- a/dns_test.go
+++ b/dns_test.go
@@ -218,3 +218,27 @@ func TestResolveTXT(t *testing.T) {
 		}
 	}
 }
+
+func TestCaseInsensitiveResolveA(t *testing.T) {
+  resolv := resolver{server: "127.0.0.1:15353"}
+  answer, err := resolv.lookup("aUtH.eXAmpLe.org", dns.TypeA)
+  if err != nil {
+    t.Errorf("%v", err)
+  }
+
+  if len(answer.Answer) == 0 {
+    t.Error("No answer for DNS query")
+  }
+}
+
+func TestCaseInsensitiveResolveSOA(t *testing.T) {
+  resolv := resolver{server: "127.0.0.1:15353"}
+  answer, _ := resolv.lookup("doesnotexist.aUtH.eXAmpLe.org", dns.TypeSOA)
+  if answer.Rcode != dns.RcodeNameError {
+    t.Errorf("Was expecing NXDOMAIN rcode, but got [%s] instead.", dns.RcodeToString[answer.Rcode])
+  }
+
+  if len(answer.Ns) == 0 {
+    t.Error("No SOA answer for DNS query")
+  }
+}

--- a/dns_test.go
+++ b/dns_test.go
@@ -140,11 +140,11 @@ func TestAuthoritative(t *testing.T) {
 	if answer.Rcode != dns.RcodeNameError {
 		t.Errorf("Was expecing NXDOMAIN rcode, but got [%s] instead.", dns.RcodeToString[answer.Rcode])
 	}
-	if len(answer.Answer) != 1 {
-		t.Errorf("Was expecting exactly one answer (SOA) for invalid subdomain, but got %d", len(answer.Answer))
+	if len(answer.Ns) != 1 {
+		t.Errorf("Was expecting exactly one answer (SOA) for invalid subdomain, but got %d", len(answer.Ns))
 	}
-	if answer.Answer[0].Header().Rrtype != dns.TypeSOA {
-		t.Errorf("Was expecting SOA record as answer for NXDOMAIN but got [%s]", dns.TypeToString[answer.Answer[0].Header().Rrtype])
+	if answer.Ns[0].Header().Rrtype != dns.TypeSOA {
+		t.Errorf("Was expecting SOA record as answer for NXDOMAIN but got [%s]", dns.TypeToString[answer.Ns[0].Header().Rrtype])
 	}
 	if !answer.MsgHdr.Authoritative {
 		t.Errorf("Was expecting authoritative bit to be set")


### PR DESCRIPTION
Respond case-insensitively to A and SOA requests. Add corresponding tests.
    
This fixes the autocert feature with Let's Encrypt, because Let's Encrypt does a lookup for the A record with a deliberately mangled case.
