### PR TITLE
auth: using headers is optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ The method allows you to update the TXT answer contents of your unique subdomain
 
 ```POST /update```
 
-#### Required headers
+#### Optional (deprecated) headers
 | Header name   | Description                                | Example                                               |
 | ------------- |--------------------------------------------|-------------------------------------------------------|
 | X-Api-User    | UUIDv4 username received from registration | `X-Api-User: c36f50e8-4632-44f0-83fe-e070fef28a10`    |
@@ -88,6 +88,7 @@ The method allows you to update the TXT answer contents of your unique subdomain
 #### Example input
 ```json
 {
+    "password": "htB9mR9DYgcu9bX_afHF62erXaH2TS7bg9KW3F7Z",
     "subdomain": "8e5700ea-a4bf-41c7-8a77-e990661dcc6a",
     "txt": "___validation_token_received_from_the_ca___"
 }
@@ -98,6 +99,7 @@ The method allows you to update the TXT answer contents of your unique subdomain
 ```Status: 200 OK```
 ```json
 {
+    "fulldomain": "8e5700ea-a4bf-41c7-8a77-e990661dcc6a.auth.acme-dns.io",
     "txt": "___validation_token_received_from_the_ca___"
 }
 ```
@@ -219,8 +221,7 @@ $ curl -X POST http://auth.example.org/register
 ```
 $ curl -X POST \
   -H "X-Api-User: eabcdb41-d89f-4580-826f-3e62e9755ef2" \
-  -H "X-Api-Key: pbAXVjlIOE01xbut7YnAbkhMQIkcwoHO0ek2j4Q0" \
-  -d '{"subdomain": "d420c923-bbd7-4056-ab64-c3ca54c9b3cf", "txt": "___validation_token_received_from_the_ca___"}' \
+  -d '{"password": "pbAXVjlIOE01xbut7YnAbkhMQIkcwoHO0ek2j4Q0", "subdomain": "d420c923-bbd7-4056-ab64-c3ca54c9b3cf", "txt": "___validation_token_received_from_the_ca___"}' \
   http://auth.example.org/update
 ```
 

--- a/api.go
+++ b/api.go
@@ -99,7 +99,7 @@ func webUpdatePost(w http.ResponseWriter, r *http.Request, _ httprouter.Params) 
 		} else {
 			log.WithFields(log.Fields{"subdomain": a.Subdomain, "txt": a.Value}).Debug("TXT updated")
 			updStatus = http.StatusOK
-			upd = []byte("{\"txt\": \"" + a.Value + "\"}")
+			upd = []byte("{\"txt\": \"" + a.Value + "\", \"fulldomain\": \"" + a.Subdomain + "." + Config.General.Domain + "\"}")
 		}
 	}
 	w.Header().Set("Content-Type", "application/json")

--- a/api.go
+++ b/api.go
@@ -71,6 +71,12 @@ func webRegisterPost(w http.ResponseWriter, r *http.Request, _ httprouter.Params
 	w.Write(reg)
 }
 
+// UpdateResponse is a struct for update response JSON
+type UpdateResponse struct {
+	TextValue  string   `json:"txt"`
+	Fulldomain string   `json:"fulldomain"`
+}
+
 func webUpdatePost(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 	var updStatus int
 	var upd []byte
@@ -99,7 +105,13 @@ func webUpdatePost(w http.ResponseWriter, r *http.Request, _ httprouter.Params) 
 		} else {
 			log.WithFields(log.Fields{"subdomain": a.Subdomain, "txt": a.Value}).Debug("TXT updated")
 			updStatus = http.StatusOK
-			upd = []byte("{\"txt\": \"" + a.Value + "\", \"fulldomain\": \"" + a.Subdomain + "." + Config.General.Domain + "\"}")
+			updStruct := UpdateResponse{a.Value, a.Subdomain + "." + Config.General.Domain}
+			upd, err = json.Marshal(updStruct)
+			if err != nil {
+				updStatus = http.StatusInternalServerError
+				upd = jsonError("json_error")
+				log.WithFields(log.Fields{"error": "json"}).Debug("Could not marshal JSON")
+			}
 		}
 	}
 	w.Header().Set("Content-Type", "application/json")

--- a/api_test.go
+++ b/api_test.go
@@ -364,7 +364,7 @@ func TestApiManyUpdateWithCredentials(t *testing.T) {
 		{"a097455b-52cc-4569-90c8-7a4b97c6eba8", "LongEnoughPassButNoUserExists___________", "bb97455b-52cc-4569-90c8-7a4b97c6eba8", validTxtData, 401},
 		{newUser.Username.String(), newUser.Password, "a097455b-52cc-4569-90c8-7a4b97c6eba8", validTxtData, 401},
 		{newUser.Username.String(), newUser.Password, newUser.Subdomain, "tooshortfortxt", 400},
-		{newUser.Username.String(), newUser.Password, newUser.Subdomain, 1234567890, 400},
+		{newUser.Username.String(), newUser.Password, newUser.Subdomain, 1234567890, 401},
 		{newUser.Username.String(), newUser.Password, newUser.Subdomain, validTxtData, 200},
 		{newUserWithCIDR.Username.String(), newUserWithCIDR.Password, newUserWithCIDR.Subdomain, validTxtData, 401},
 		{newUserWithValidCIDR.Username.String(), newUserWithValidCIDR.Password, newUserWithValidCIDR.Subdomain, validTxtData, 200},

--- a/auth.go
+++ b/auth.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"net"
 	"net/http"
 
@@ -19,31 +18,42 @@ const ACMETxtKey key = 0
 // Auth middleware for update request
 func Auth(update httprouter.Handle) httprouter.Handle {
 	return func(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
-		postData := ACMETxt{}
 		userOK := false
-		user, err := getUserFromRequest(r)
-		if err == nil {
-			if updateAllowedFromIP(r, user) {
-				dec := json.NewDecoder(r.Body)
-				err = dec.Decode(&postData)
-				if err != nil {
-					log.WithFields(log.Fields{"error": "json_error", "string": err.Error()}).Error("Decode error")
-				}
-				if user.Subdomain == postData.Subdomain {
-					userOK = true
-				} else {
-					log.WithFields(log.Fields{"error": "subdomain_mismatch", "name": postData.Subdomain, "expected": user.Subdomain}).Error("Subdomain mismatch")
-				}
-			} else {
-				log.WithFields(log.Fields{"error": "ip_unauthorized"}).Error("Update not allowed from IP")
-			}
+		userSupplied := false
+		user := ACMETxt{}
+		postData, err := decodePostData(r)
+		if err != nil {
+			log.WithFields(log.Fields{"error": "json_error", "string": err.Error()}).Error("Decode error")
 		} else {
-			log.WithFields(log.Fields{"error": err.Error()}).Error("Error while trying to get user")
+			userSupplied = getCredsFromRequest(r, &postData)
+		}
+		if !validSubdomain(postData.Subdomain) {
+			log.WithFields(log.Fields{"error": "invalid_subdomain"}).Error("Invalid subdomain UUID")
+		} else {
+			user, err = DB.GetBySubdomain(postData.Subdomain)
+			if err != nil {
+				log.WithFields(log.Fields{"error": "subdomain_not_found", "string": err.Error()}).Error("Subdomain is not registered")
+			} else {
+				if updateAllowedFromIP(r, user) {
+					if correctPassword(postData.Password, user.Password) {
+						if userSupplied {
+							userOK = postData.Username == user.Username
+						} else {
+							userOK = true
+						}
+					} else {
+						log.WithFields(log.Fields{"error": "invalid_password"}).Error("Password was not correct")
+					}
+				} else {
+					log.WithFields(log.Fields{"error": "ip_unauthorized"}).Error("Update not allowed from IP")
+				}
+			}
 		}
 		if userOK {
 			// Set user info to the decoded ACMETxt object
 			postData.Username = user.Username
 			postData.Password = user.Password
+			postData.Subdomain = user.Subdomain
 			// Set the ACMETxt struct to context to pull in from update function
 			ctx := context.WithValue(r.Context(), ACMETxtKey, postData)
 			update(w, r.WithContext(ctx), p)
@@ -55,28 +65,31 @@ func Auth(update httprouter.Handle) httprouter.Handle {
 	}
 }
 
-func getUserFromRequest(r *http.Request) (ACMETxt, error) {
-	uname := r.Header.Get("X-Api-User")
-	passwd := r.Header.Get("X-Api-Key")
-	username, err := getValidUsername(uname)
+func decodePostData(r *http.Request) (ACMETxt, error) {
+	postData := ACMETxt{}
+	dec := json.NewDecoder(r.Body)
+	err := dec.Decode(&postData)
 	if err != nil {
-		return ACMETxt{}, fmt.Errorf("Invalid username: %s: %s", uname, err.Error())
+		return ACMETxt{}, err
 	}
-	if validKey(passwd) {
-		dbuser, err := DB.GetByUsername(username)
-		if err != nil {
-			log.WithFields(log.Fields{"error": err.Error()}).Error("Error while trying to get user")
-			// To protect against timed side channel (never gonna give you up)
-			correctPassword(passwd, "$2a$10$8JEFVNYYhLoBysjAxe2yBuXrkDojBQBkVpXEQgyQyjn43SvJ4vL36")
+	return postData, nil
+}
 
-			return ACMETxt{}, fmt.Errorf("Invalid username: %s", uname)
+func getCredsFromRequest(r *http.Request, postData *ACMETxt) bool {
+	if !validKey(postData.Password) {
+		key := r.Header.Get("X-Api-Key")
+		if validKey(key) {
+			postData.Password = key
 		}
-		if correctPassword(passwd, dbuser.Password) {
-			return dbuser, nil
-		}
-		return ACMETxt{}, fmt.Errorf("Invalid password for user %s", uname)
 	}
-	return ACMETxt{}, fmt.Errorf("Invalid key for user %s", uname)
+
+	user := r.Header.Get("X-Api-User")
+	uname, err := getValidUsername(user)
+	if err != nil {
+		return false
+	}
+	postData.Username = uname
+	return true
 }
 
 func updateAllowedFromIP(r *http.Request, user ACMETxt) bool {

--- a/db_test.go
+++ b/db_test.go
@@ -76,6 +76,32 @@ func TestRegisterMany(t *testing.T) {
 	}
 }
 
+func TestGetBySubdomain(t *testing.T) {
+	// Create  reg to refer to
+	reg, err := DB.Register(cidrslice{})
+	if err != nil {
+		t.Errorf("Registration failed, got error [%v]", err)
+	}
+
+	regUser, err := DB.GetBySubdomain(reg.Subdomain)
+	if err != nil {
+		t.Errorf("Could not get test user, got error [%v]", err)
+	}
+
+	if reg.Username != regUser.Username {
+		t.Errorf("GetBySubdomain username [%q] did not match the original [%q]", regUser.Username, reg.Username)
+	}
+
+	if reg.Subdomain != regUser.Subdomain {
+		t.Errorf("GetBySubdomain subdomain [%q] did not match the original [%q]", regUser.Subdomain, reg.Subdomain)
+	}
+
+	// regUser password already is a bcrypt hash
+	if !correctPassword(reg.Password, regUser.Password) {
+		t.Errorf("GetBySubdomain password [%s] does not match the hash [%s]", reg.Password, regUser.Password)
+	}
+}
+
 func TestGetByUsername(t *testing.T) {
 	// Create  reg to refer to
 	reg, err := DB.Register(cidrslice{})
@@ -98,7 +124,7 @@ func TestGetByUsername(t *testing.T) {
 
 	// regUser password already is a bcrypt hash
 	if !correctPassword(reg.Password, regUser.Password) {
-		t.Errorf("The password [%s] does not match the hash [%s]", reg.Password, regUser.Password)
+		t.Errorf("GetByUsername password [%s] does not match the hash [%s]", reg.Password, regUser.Password)
 	}
 }
 

--- a/dns.go
+++ b/dns.go
@@ -55,7 +55,7 @@ func (d *DNSServer) ParseRecords(config DNSConfig) {
 	// Create serial
 	serial := time.Now().Format("2006010215")
 	// Add SOA
-	SOAstring := fmt.Sprintf("%s. SOA %s. %s. %s 28800 7200 604800 86400", strings.ToLower(config.General.Domain), strings.ToLower(config.General.Nsname), strings.ToLower(config.General.Nsadmin), serial)
+	SOAstring := fmt.Sprintf("%s. SOA %s. %s. %s 28800 7200 604800 3600", strings.ToLower(config.General.Domain), strings.ToLower(config.General.Nsname), strings.ToLower(config.General.Nsadmin), serial)
 	soarr, err := dns.NewRR(SOAstring)
 	if err != nil {
 		log.WithFields(log.Fields{"error": err.Error(), "soa": SOAstring}).Error("Error while adding SOA record")
@@ -188,7 +188,7 @@ func (d *DNSServer) answerTXT(q dns.Question) ([]dns.RR, error) {
 	for _, v := range atxt {
 		if len(v) > 0 {
 			r := new(dns.TXT)
-			r.Hdr = dns.RR_Header{Name: q.Name, Rrtype: dns.TypeTXT, Class: dns.ClassINET, Ttl: 1}
+			r.Hdr = dns.RR_Header{Name: q.Name, Rrtype: dns.TypeTXT, Class: dns.ClassINET, Ttl: 10}
 			r.Txt = append(r.Txt, v)
 			ra = append(ra, r)
 		}

--- a/types.go
+++ b/types.go
@@ -72,6 +72,7 @@ type acmedb struct {
 type database interface {
 	Init(string, string) error
 	Register(cidrslice) (ACMETxt, error)
+	GetBySubdomain(string) (ACMETxt, error)
 	GetByUsername(uuid.UUID) (ACMETxt, error)
 	GetTXTForDomain(string) ([]string, error)
 	Update(ACMETxt) error

--- a/validation.go
+++ b/validation.go
@@ -7,6 +7,14 @@ import (
 	"golang.org/x/crypto/bcrypt"
 )
 
+func getValidSubdomain(s string) (uuid.UUID, error) {
+	subdomain, err := uuid.Parse(s)
+	if err != nil {
+		return uuid.UUID{}, err
+	}
+	return subdomain, nil
+}
+
 func getValidUsername(u string) (uuid.UUID, error) {
 	uname, err := uuid.Parse(u)
 	if err != nil {

--- a/validation.go
+++ b/validation.go
@@ -33,7 +33,7 @@ func validKey(k string) bool {
 }
 
 func validSubdomain(s string) bool {
-	_, err := uuid.Parse(s)
+	_, err := getValidSubdomain(s)
 	if err == nil {
 		return true
 	}

--- a/validation_test.go
+++ b/validation_test.go
@@ -6,6 +6,31 @@ import (
 	"github.com/google/uuid"
 )
 
+func TestGetValidSubdomain(t *testing.T) {
+	v1, _ := uuid.Parse("a097455b-52cc-4569-90c8-7a4b97c6eba8")
+	for i, test := range []struct {
+		subdomain     string
+		output    uuid.UUID
+		shouldErr bool
+	}{
+		{"a097455b-52cc-4569-90c8-7a4b97c6eba8", v1, false},
+		{"a-97455b-52cc-4569-90c8-7a4b97c6eba8", uuid.UUID{}, true},
+		{"", uuid.UUID{}, true},
+		{"&!#!25123!%!'%", uuid.UUID{}, true},
+	} {
+		ret, err := getValidSubdomain(test.subdomain)
+		if test.shouldErr && err == nil {
+			t.Errorf("Test %d: Expected error, but there was none", i)
+		}
+		if !test.shouldErr && err != nil {
+			t.Errorf("Test %d: Expected no error, but got [%v]", i, err)
+		}
+		if ret != test.output {
+			t.Errorf("Test %d: Expected return value %v, but got %v", i, test.output, ret)
+		}
+	}
+}
+
 func TestGetValidUsername(t *testing.T) {
 	v1, _ := uuid.Parse("a097455b-52cc-4569-90c8-7a4b97c6eba8")
 	for i, test := range []struct {
@@ -49,7 +74,7 @@ func TestValidKey(t *testing.T) {
 	}
 }
 
-func TestGetValidSubdomain(t *testing.T) {
+func TestValidSubdomain(t *testing.T) {
 	for i, test := range []struct {
 		subdomain string
 		output    bool


### PR DESCRIPTION
The POST data now contains:

- txt
- subdomain
- password

This still checks `X-Api-Key` and `X-Api-User` for backwards compatibility. If a user is provided we'll still check it, but it is now optional.

This should address most of https://github.com/joohoi/acme-dns/issues/77 too.