### PR TITLE
Add the possibility to manage multiple domains automatically

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ acme-dns.log
 .vagrant
 coverage.out
 .idea/
+
+.git/

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ LABEL maintainer="joona@kuori.org"
 
 RUN apk add --update gcc musl-dev git
 
-RUN go get github.com/joohoi/acme-dns
+COPY . /go/src/github.com/joohoi/acme-dns
+# RUN go get github.com/joohoi/acme-dns
 WORKDIR /go/src/github.com/joohoi/acme-dns
 RUN CGO_ENABLED=1 go build
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,17 @@ So basically it boils down to **accessibility** and **security**.
 - Rolling update of two TXT records to be able to answer to challenges for certificates that have both names: `yourdomain.tld` and `*.yourdomain.tld`, as both of the challenges point to the same subdomain.
 - Simple deployment (it's Go after all)
 
+## Features in OSSO's ossobv-readable-subdomains
+- Create a single account with a good password
+- Manually set subdomain in `records` to `*` to allow setting of all subdomains
+- Use this configuration: `CHALLENGE.your.tld NS ACMEDNS.your.tld` in static config
+- Then register SUBDOMAIN ("example.com") instead of GUID ("...") which gets tacked onto your hosted domain
+- Point peoples `_acme-challenge` to your domains:
+- `_acme-challenge.example.com CNAME example.com.CHALLENGE.your.tld`
+- `_acme-challenge.www.example.com CNAME www.example.com.CHALLENGE.your.tld`
+- You'll need a slightly adapted version of the `acme-dns-certbot`
+- Now you can manage multiple domains/subdomains easily
+
 ## Usage
 
 A Certbot authentication hook for acme-dns is available at: [https://github.com/joohoi/acme-dns-certbot](https://github.com/joohoi/acme-dns-certbot).

--- a/auth.go
+++ b/auth.go
@@ -29,7 +29,7 @@ func Auth(update httprouter.Handle) httprouter.Handle {
 				if err != nil {
 					log.WithFields(log.Fields{"error": "json_error", "string": err.Error()}).Error("Decode error")
 				}
-				if user.Subdomain == postData.Subdomain {
+				if user.Subdomain == "*" || user.Subdomain == postData.Subdomain {
 					userOK = true
 				} else {
 					log.WithFields(log.Fields{"error": "subdomain_mismatch", "name": postData.Subdomain, "expected": user.Subdomain}).Error("Subdomain mismatch")

--- a/types.go
+++ b/types.go
@@ -74,6 +74,7 @@ type database interface {
 	Register(cidrslice) (ACMETxt, error)
 	GetByUsername(uuid.UUID) (ACMETxt, error)
 	GetTXTForDomain(string) ([]string, error)
+	UpdatePreCreate(ACMETxt) error
 	Update(ACMETxt) error
 	GetBackend() *sql.DB
 	SetBackend(*sql.DB)

--- a/validation.go
+++ b/validation.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"regexp"
 	"unicode/utf8"
 
 	"github.com/google/uuid"
@@ -25,6 +26,11 @@ func validKey(k string) bool {
 }
 
 func validSubdomain(s string) bool {
+	// validate sane domain name part, like "com" or "a-b-c.com"
+	if (regexp.MustCompile(`^([a-z0-9]([a-z0-9-]*[a-z0-9])?)([.][a-z0-9]([a-z0-9-]*[a-z0-9])?)*$`).MatchString(s)) {
+		return true
+	}
+	// validate uuid, like "d25989a6-c59a-4670-b294-a8cb0c5ad8d2"
 	_, err := uuid.Parse(s)
 	if err == nil {
 		return true


### PR DESCRIPTION
By setting the ``records`` subdomain to ``*`` you allow the account to
autoregister new subdomains.

Use ``_acme-challenge.example.com CNAME example.com.your-challenge.tld``
CNAMEs on all domains you wish to manage letsencrypt certificates for.

----

Hi Joona, I don't expect you to merge this verbatim, but I thought I'd let you know how I changed some stuff around for usability over here.

Thanks for the work!

Feel free to close this PR.