### PR TITLE
Refactor: Use more specific type in argument of DB.Update

### DIFF
--- a/api.go
+++ b/api.go
@@ -91,7 +91,7 @@ func webUpdatePost(w http.ResponseWriter, r *http.Request, _ httprouter.Params) 
 		updStatus = http.StatusBadRequest
 		upd = jsonError("bad_txt")
 	} else if validSubdomain(a.Subdomain) && validTXT(a.Value) {
-		err := DB.Update(a)
+		err := DB.Update(a.ACMETxtPost)
 		if err != nil {
 			log.WithFields(log.Fields{"error": err.Error()}).Debug("Error while trying to update record")
 			updStatus = http.StatusInternalServerError

--- a/db.go
+++ b/db.go
@@ -281,7 +281,7 @@ func (d *acmedb) GetTXTForDomain(domain string) ([]string, error) {
 	return txts, nil
 }
 
-func (d *acmedb) Update(a ACMETxt) error {
+func (d *acmedb) Update(a ACMETxtPost) error {
 	d.Lock()
 	defer d.Unlock()
 	var err error

--- a/db_test.go
+++ b/db_test.go
@@ -161,7 +161,7 @@ func TestQueryExecErrors(t *testing.T) {
 		t.Errorf("Expected error from exec in Register, but got none")
 	}
 	reg.Value = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-	err = DB.Update(reg)
+	err = DB.Update(reg.ACMETxtPost)
 	if err == nil {
 		t.Errorf("Expected error from exec in Update, but got none")
 	}
@@ -238,10 +238,10 @@ func TestGetTXTForDomain(t *testing.T) {
 	txtval2 := "___validation_token_received_YEAH_the_ca___"
 
 	reg.Value = txtval1
-	_ = DB.Update(reg)
+	_ = DB.Update(reg.ACMETxtPost)
 
 	reg.Value = txtval2
-	_ = DB.Update(reg)
+	_ = DB.Update(reg.ACMETxtPost)
 
 	regDomainSlice, err := DB.GetTXTForDomain(reg.Subdomain)
 	if err != nil {
@@ -294,7 +294,7 @@ func TestUpdate(t *testing.T) {
 	regUser.Password = "nevergonnagiveyouup"
 	regUser.Value = validTXT
 
-	err = DB.Update(regUser)
+	err = DB.Update(regUser.ACMETxtPost)
 	if err != nil {
 		t.Errorf("DB Update failed, got error: [%v]", err)
 	}

--- a/dns_test.go
+++ b/dns_test.go
@@ -168,7 +168,7 @@ func TestResolveTXT(t *testing.T) {
 		return
 	}
 	atxt.Value = validTXT
-	err = DB.Update(atxt)
+	err = DB.Update(atxt.ACMETxtPost)
 	if err != nil {
 		t.Errorf("Could not update db record: [%v]", err)
 		return

--- a/types.go
+++ b/types.go
@@ -74,7 +74,7 @@ type database interface {
 	Register(cidrslice) (ACMETxt, error)
 	GetByUsername(uuid.UUID) (ACMETxt, error)
 	GetTXTForDomain(string) ([]string, error)
-	Update(ACMETxt) error
+	Update(ACMETxtPost) error
 	GetBackend() *sql.DB
 	SetBackend(*sql.DB)
 	Close()


### PR DESCRIPTION
The DB.Update function takes a type of ACMETxt. However, the function
only requires the Value and Subdomain fields.

Refactor the function such that it takes ACMETxtPost instead of the full
ACMETxt record. This will simplify extraction of txt-record related
logic from the db code.