### PR TITLE
Update acme-dns.service

### DIFF
--- a/acme-dns.service
+++ b/acme-dns.service
@@ -6,6 +6,7 @@ After=network.target
 User=acme-dns
 Group=acme-dns
 AmbientCapabilities=CAP_NET_BIND_SERVICE
+WorkingDirectory=~
 ExecStart=/usr/local/bin/acme-dns
 Restart=on-failure
 


### PR DESCRIPTION
Set working directory to service users home. 
If it's not set then the service defaults to "/" and it fails to create the api-certs directory.