### PR TITLE
Add support for LE expiration notification e-mails on API cert

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,8 @@ tls_cert_privkey = "/etc/tls/example.org/privkey.pem"
 tls_cert_fullchain = "/etc/tls/example.org/fullchain.pem"
 # only used if tls = "letsencrypt"
 acme_cache_dir = "api-certs"
+# optional e-mail address to which Let's Encrypt will send expiration notices for the API's cert
+notification_email = ""
 # CORS AllowOrigins, wildcards can be used
 corsorigins = [
     "*"

--- a/config.cfg
+++ b/config.cfg
@@ -43,6 +43,8 @@ tls_cert_privkey = "/etc/tls/example.org/privkey.pem"
 tls_cert_fullchain = "/etc/tls/example.org/fullchain.pem"
 # only used if tls = "letsencrypt"
 acme_cache_dir = "api-certs"
+# optional e-mail address to which Let's Encrypt will send expiration notices for the API's cert
+notification_email = ""
 # CORS AllowOrigins, wildcards can be used
 corsorigins = [
     "*"

--- a/main.go
+++ b/main.go
@@ -149,6 +149,7 @@ func startHTTPAPI(errChan chan error, config DNSConfig, dnsservers []*DNSServer)
 		DNSProvider:        &provider,
 		DNSChallengeOption: dnsopts,
 		DefaultServerName:  Config.General.Domain,
+		Email:              Config.API.NotificationEmail,
 		Storage:            &storage,
 	}
 

--- a/types.go
+++ b/types.go
@@ -51,6 +51,7 @@ type httpapi struct {
 	TLSCertPrivkey      string `toml:"tls_cert_privkey"`
 	TLSCertFullchain    string `toml:"tls_cert_fullchain"`
 	ACMECacheDir        string `toml:"acme_cache_dir"`
+	NotificationEmail   string `toml:"notification_email"`
 	CorsOrigins         []string
 	UseHeader           bool   `toml:"use_header"`
 	HeaderName          string `toml:"header_name"`


### PR DESCRIPTION
### Summary:

This PR adds support for setting an e-mail address in the config file that Let's Encrypt can use to send notification e-mails if the API's certificate is expiring soon.  When an account at LE is registered and an e-mail address is provided, LE will use this address for this purpose:
https://letsencrypt.org/docs/expiration-emails/

This is a helpful, optional service that LE offers for free, and the e-mails can be useful for an admin to be alerted to potential certificate renewal issues that might otherwise go unnoticed.

The new config option `notification_email` is an empty string by default, preserving the previous behavior of not registering any address with LE upon account creation.  If the user fills in an e-mail address, this value will be used during account creation with LE.

The value of `notification_email` is passed through to CertMagic and leverages their existing support for this feature.

### Example:

Where the config file includes these entries:
```ini
[api]
# possible values: "letsencrypt", "letsencryptstaging", "cert", "none"
tls = "letsencryptstaging"
# only used if tls = "letsencrypt"
acme_cache_dir = "api-certs"
# optional e-mail address to which Let's Encrypt will send expiration notices for the API's cert
notification_email = "myuser@mydomain.com"
```

This patch yields the following results:
```console
$ sudo rm -Rf /var/lib/acme-dns/api-certs
$ sudo systemctl start acme-dns
$ journalctl -u acme-dns --no-pager | grep -A2 'certificate maintenance'
Apr 28 18:25:38 ns1 acme-dns[13286]: time="2020-04-28T18:25:38-05:00" level=info msg="2020/04/28 18:25:38 [INFO][cache:0xc00008e5f0] Started certificate maintenance routine"
Apr 28 18:25:38 ns1 acme-dns[13286]: time="2020-04-28T18:25:38-05:00" level=info msg="[INFO] acme: Registering account for myuser@mydomain.com"
Apr 28 18:25:38 ns1 acme-dns[13286]: time="2020-04-28T18:25:38-05:00" level=info msg="2020/04/28 18:25:38 [INFO][ns1.certs.mydomain.com] Obtain certificate"

$ sudo ls /var/lib/acme-dns/api-certs/acme/acme-staging-v02.api.letsencrypt.org/users
myuser@mydomain.com

$ sudo cat /var/lib/acme-dns/api-certs/acme/acme-staging-v02.api.letsencrypt.org/users/myuser@mydomain.com/myuser.json
{
        "Email": "myuser@mydomain.com",
        "Registration": {
                "body": {
                        "status": "valid",
                        "contact": [
                                "mailto:myuser@mydomain.com"
                        ]
                },
                "uri": "https://acme-staging-v02.api.letsencrypt.org/acme/acct/12345678"
        }
}
```
