### PR TITLE
README: Use https URLs for API testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ You may want to test that acme-dns is working before using it for real queries.
 
 2) Call the `/register` API endpoint to register a test domain:
 ```
-$ curl -X POST http://auth.example.org/register
+$ curl -X POST https://auth.example.org/register
 {"username":"eabcdb41-d89f-4580-826f-3e62e9755ef2","password":"pbAXVjlIOE01xbut7YnAbkhMQIkcwoHO0ek2j4Q0","fulldomain":"d420c923-bbd7-4056-ab64-c3ca54c9b3cf.auth.example.org","subdomain":"d420c923-bbd7-4056-ab64-c3ca54c9b3cf","allowfrom":[]}
 ```
 
@@ -216,7 +216,7 @@ $ curl -X POST \
   -H "X-Api-User: eabcdb41-d89f-4580-826f-3e62e9755ef2" \
   -H "X-Api-Key: pbAXVjlIOE01xbut7YnAbkhMQIkcwoHO0ek2j4Q0" \
   -d '{"subdomain": "d420c923-bbd7-4056-ab64-c3ca54c9b3cf", "txt": "___validation_token_received_from_the_ca___"}' \
-  http://auth.example.org/update
+  https://auth.example.org/update
 ```
 
 Note: The `txt` field must be exactly 43 characters long, otherwise acme-dns will reject it


### PR DESCRIPTION
The examples in [Testing It Out](https://github.com/joohoi/acme-dns#testing-it-out) use `http`, but in reality one would use `https`. Consistency helps ease of understanding for the newcomer.