### PR TITLE
Allow set-and-delete flow that is usually used by acme-clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,9 +77,40 @@ With the credentials, you can update the TXT response in the service to match th
 
 ### Update endpoint
 
-The method allows you to update the TXT answer contents of your unique subdomain. Usually carried automatically by automated ACME client.
+This method allows you to insert TXT records for your unique subdomain. Usually carried automatically by automated ACME client.
 
 ```POST /update```
+
+#### Required headers
+| Header name   | Description                                | Example                                               |
+| ------------- |--------------------------------------------|-------------------------------------------------------|
+| X-Api-User    | UUIDv4 username received from registration | `X-Api-User: c36f50e8-4632-44f0-83fe-e070fef28a10`    |
+| X-Api-Key     | Password received from registration        | `X-Api-Key: htB9mR9DYgcu9bX_afHF62erXaH2TS7bg9KW3F7Z` |
+
+#### Example input
+```json
+{
+    "subdomain": "8e5700ea-a4bf-41c7-8a77-e990661dcc6a",
+    "txt": "___validation_token_received_from_the_ca___"
+}
+```
+
+#### Response
+
+```Status: 200 OK```
+```json
+{
+    "txt": "___validation_token_received_from_the_ca___"
+}
+```
+
+
+### Delete endpoint
+
+This method allows you to delete TXT records of your unique subdomain after they have been used for validation.
+Usually carried automatically by automated ACME client.
+
+```POST /delete```
 
 #### Required headers
 | Header name   | Description                                | Example                                               |

--- a/api.go
+++ b/api.go
@@ -140,7 +140,7 @@ func webDeletePost(w http.ResponseWriter, r *http.Request, _ httprouter.Params) 
 	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(delStatus)
-	w.Write(del)
+	_, _ = w.Write(del)
 }
 
 // Endpoint used to check the readiness and/or liveness (health) of the server.

--- a/api.go
+++ b/api.go
@@ -107,6 +107,42 @@ func webUpdatePost(w http.ResponseWriter, r *http.Request, _ httprouter.Params) 
 	_, _ = w.Write(upd)
 }
 
+func webDeletePost(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	var delStatus int
+	var del []byte
+	// Get user
+	a, ok := r.Context().Value(ACMETxtKey).(ACMETxt)
+	if !ok {
+		log.WithFields(log.Fields{"error": "context"}).Error("Context error")
+	}
+	// NOTE: An invalid subdomain should not happen - the auth handler should
+	// reject POSTs with an invalid subdomain before this handler. Reject any
+	// invalid subdomains anyway as a matter of caution.
+	if !validSubdomain(a.Subdomain) {
+		log.WithFields(log.Fields{"error": "subdomain", "subdomain": a.Subdomain, "txt": a.Value}).Debug("Bad delete data")
+		delStatus = http.StatusBadRequest
+		del = jsonError("bad_subdomain")
+	} else if !validTXT(a.Value) {
+		log.WithFields(log.Fields{"error": "txt", "subdomain": a.Subdomain, "txt": a.Value}).Debug("Bad delete data")
+		delStatus = http.StatusBadRequest
+		del = jsonError("bad_txt")
+	} else if validSubdomain(a.Subdomain) && validTXT(a.Value) {
+		err := DB.Delete(a.ACMETxtPost)
+		if err != nil {
+			log.WithFields(log.Fields{"error": err.Error()}).Debug("Error while trying to delete record")
+			delStatus = http.StatusInternalServerError
+			del = jsonError("db_error")
+		} else {
+			log.WithFields(log.Fields{"subdomain": a.Subdomain, "txt": a.Value}).Debug("TXT deleted")
+			delStatus = http.StatusOK
+			del = []byte("{\"txt\": \"" + a.Value + "\"}")
+		}
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(delStatus)
+	w.Write(del)
+}
+
 // Endpoint used to check the readiness and/or liveness (health) of the server.
 func healthCheck(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 	w.WriteHeader(http.StatusOK)

--- a/api_test.go
+++ b/api_test.go
@@ -416,7 +416,7 @@ func TestApiUpdateWithCredentialsMockDB(t *testing.T) {
 	DB.SetBackend(db)
 	defer db.Close()
 	mock.ExpectBegin()
-	mock.ExpectPrepare("UPDATE records").WillReturnError(errors.New("error"))
+	mock.ExpectPrepare("INSERT INTO txt").WillReturnError(errors.New("error"))
 	e.POST("/update").
 		WithJSON(updateJSON).
 		Expect().
@@ -445,7 +445,7 @@ func TestApiDeleteWithCredentialsMockDB(t *testing.T) {
 	DB.SetBackend(db)
 	defer db.Close()
 	mock.ExpectBegin()
-	mock.ExpectPrepare("UPDATE records").WillReturnError(errors.New("error"))
+	mock.ExpectPrepare("DELETE FROM txt").WillReturnError(errors.New("error"))
 	e.POST("/delete").
 		WithJSON(updateJSON).
 		Expect().

--- a/api_test.go
+++ b/api_test.go
@@ -74,8 +74,10 @@ func setupRouter(debug bool, noauth bool) http.Handler {
 	api.GET("/health", healthCheck)
 	if noauth {
 		api.POST("/update", noAuth(webUpdatePost))
+		api.POST("/delete", noAuth(webDeletePost))
 	} else {
 		api.POST("/update", Auth(webUpdatePost))
+		api.POST("/delete", Auth(webDeletePost))
 	}
 	return c.Handler(api)
 }
@@ -221,6 +223,36 @@ func TestApiUpdateWithInvalidSubdomain(t *testing.T) {
 		ValueEqual("error", "forbidden")
 }
 
+func TestApiDeleteWithInvalidSubdomain(t *testing.T) {
+	validTxtData := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+	updateJSON := map[string]interface{}{
+		"subdomain": "",
+		"txt":       ""}
+
+	router := setupRouter(false, false)
+	server := httptest.NewServer(router)
+	defer server.Close()
+	e := getExpect(t, server)
+	newUser, err := DB.Register(cidrslice{})
+	if err != nil {
+		t.Errorf("Could not create new user, got error [%v]", err)
+	}
+	// Invalid subdomain data
+	updateJSON["subdomain"] = "example.com"
+	updateJSON["txt"] = validTxtData
+	e.POST("/delete").
+		WithJSON(updateJSON).
+		WithHeader("X-Api-User", newUser.Username.String()).
+		WithHeader("X-Api-Key", newUser.Password).
+		Expect().
+		Status(http.StatusUnauthorized).
+		JSON().Object().
+		ContainsKey("error").
+		NotContainsKey("txt").
+		ValueEqual("error", "forbidden")
+}
+
 func TestApiUpdateWithInvalidTxt(t *testing.T) {
 	invalidTXTData := "idk m8 bbl lmao"
 
@@ -251,12 +283,54 @@ func TestApiUpdateWithInvalidTxt(t *testing.T) {
 		ValueEqual("error", "bad_txt")
 }
 
+func TestApiDeleteWithInvalidTxt(t *testing.T) {
+	invalidTXTData := "idk m8 bbl lmao"
+
+	updateJSON := map[string]interface{}{
+		"subdomain": "",
+		"txt":       ""}
+
+	router := setupRouter(false, false)
+	server := httptest.NewServer(router)
+	defer server.Close()
+	e := getExpect(t, server)
+	newUser, err := DB.Register(cidrslice{})
+	if err != nil {
+		t.Errorf("Could not create new user, got error [%v]", err)
+	}
+	updateJSON["subdomain"] = newUser.Subdomain
+	// Invalid txt data
+	updateJSON["txt"] = invalidTXTData
+	e.POST("/delete").
+		WithJSON(updateJSON).
+		WithHeader("X-Api-User", newUser.Username.String()).
+		WithHeader("X-Api-Key", newUser.Password).
+		Expect().
+		Status(http.StatusBadRequest).
+		JSON().Object().
+		ContainsKey("error").
+		NotContainsKey("txt").
+		ValueEqual("error", "bad_txt")
+}
+
 func TestApiUpdateWithoutCredentials(t *testing.T) {
 	router := setupRouter(false, false)
 	server := httptest.NewServer(router)
 	defer server.Close()
 	e := getExpect(t, server)
 	e.POST("/update").Expect().
+		Status(http.StatusUnauthorized).
+		JSON().Object().
+		ContainsKey("error").
+		NotContainsKey("txt")
+}
+
+func TestApiDeleteWithoutCredentials(t *testing.T) {
+	router := setupRouter(false, false)
+	server := httptest.NewServer(router)
+	defer server.Close()
+	e := getExpect(t, server)
+	e.POST("/delete").Expect().
 		Status(http.StatusUnauthorized).
 		JSON().Object().
 		ContainsKey("error").
@@ -293,6 +367,36 @@ func TestApiUpdateWithCredentials(t *testing.T) {
 		ValueEqual("txt", validTxtData)
 }
 
+func TestApiDeleteWithCredentials(t *testing.T) {
+	validTxtData := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+	updateJSON := map[string]interface{}{
+		"subdomain": "",
+		"txt":       ""}
+
+	router := setupRouter(false, false)
+	server := httptest.NewServer(router)
+	defer server.Close()
+	e := getExpect(t, server)
+	newUser, err := DB.Register(cidrslice{})
+	if err != nil {
+		t.Errorf("Could not create new user, got error [%v]", err)
+	}
+	// Valid data
+	updateJSON["subdomain"] = newUser.Subdomain
+	updateJSON["txt"] = validTxtData
+	e.POST("/delete").
+		WithJSON(updateJSON).
+		WithHeader("X-Api-User", newUser.Username.String()).
+		WithHeader("X-Api-Key", newUser.Password).
+		Expect().
+		Status(http.StatusOK).
+		JSON().Object().
+		ContainsKey("txt").
+		NotContainsKey("error").
+		ValueEqual("txt", validTxtData)
+}
+
 func TestApiUpdateWithCredentialsMockDB(t *testing.T) {
 	validTxtData := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 	updateJSON := map[string]interface{}{
@@ -314,6 +418,35 @@ func TestApiUpdateWithCredentialsMockDB(t *testing.T) {
 	mock.ExpectBegin()
 	mock.ExpectPrepare("UPDATE records").WillReturnError(errors.New("error"))
 	e.POST("/update").
+		WithJSON(updateJSON).
+		Expect().
+		Status(http.StatusInternalServerError).
+		JSON().Object().
+		ContainsKey("error")
+	DB.SetBackend(oldDb)
+}
+
+func TestApiDeleteWithCredentialsMockDB(t *testing.T) {
+	validTxtData := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	updateJSON := map[string]interface{}{
+		"subdomain": "",
+		"txt":       ""}
+
+	// Valid data
+	updateJSON["subdomain"] = "a097455b-52cc-4569-90c8-7a4b97c6eba8"
+	updateJSON["txt"] = validTxtData
+
+	router := setupRouter(false, true)
+	server := httptest.NewServer(router)
+	defer server.Close()
+	e := getExpect(t, server)
+	oldDb := DB.GetBackend()
+	db, mock, _ := sqlmock.New()
+	DB.SetBackend(db)
+	defer db.Close()
+	mock.ExpectBegin()
+	mock.ExpectPrepare("UPDATE records").WillReturnError(errors.New("error"))
+	e.POST("/delete").
 		WithJSON(updateJSON).
 		Expect().
 		Status(http.StatusInternalServerError).
@@ -379,6 +512,67 @@ func TestApiManyUpdateWithCredentials(t *testing.T) {
 	}
 }
 
+func TestApiManyDeleteWithCredentials(t *testing.T) {
+	validTxtData := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+	updateJSON := map[string]interface{}{
+		"subdomain": "",
+		"txt":       ""}
+
+	router := setupRouter(true, false)
+	server := httptest.NewServer(router)
+	defer server.Close()
+	e := getExpect(t, server)
+	// User without defined CIDR masks
+	newUser, err := DB.Register(cidrslice{})
+	if err != nil {
+		t.Errorf("Could not create new user, got error [%v]", err)
+	}
+
+	// User with defined allow from - CIDR masks, all invalid
+	// (httpexpect doesn't provide a way to mock remote ip)
+	newUserWithCIDR, err := DB.Register(cidrslice{"192.168.1.1/32", "invalid"})
+	if err != nil {
+		t.Errorf("Could not create new user with CIDR, got error [%v]", err)
+	}
+
+	// Another user with valid CIDR mask to match the httpexpect default
+	newUserWithValidCIDR, err := DB.Register(cidrslice{"10.1.2.3/32", "invalid"})
+	if err != nil {
+		t.Errorf("Could not create new user with a valid CIDR, got error [%v]", err)
+	}
+
+	for _, test := range []struct {
+		user      string
+		pass      string
+		subdomain string
+		txt       interface{}
+		status    int
+	}{
+		{"non-uuid-user", "tooshortpass", "non-uuid-subdomain", validTxtData, 401},
+		{"a097455b-52cc-4569-90c8-7a4b97c6eba8", "tooshortpass", "bb97455b-52cc-4569-90c8-7a4b97c6eba8", validTxtData, 401},
+		{"a097455b-52cc-4569-90c8-7a4b97c6eba8", "LongEnoughPassButNoUserExists___________", "bb97455b-52cc-4569-90c8-7a4b97c6eba8", validTxtData, 401},
+		{newUser.Username.String(), newUser.Password, "a097455b-52cc-4569-90c8-7a4b97c6eba8", validTxtData, 401},
+		{newUser.Username.String(), newUser.Password, newUser.Subdomain, "tooshortfortxt", 400},
+		{newUser.Username.String(), newUser.Password, newUser.Subdomain, 1234567890, 400},
+		{newUser.Username.String(), newUser.Password, newUser.Subdomain, validTxtData, 200},
+		{newUserWithCIDR.Username.String(), newUserWithCIDR.Password, newUserWithCIDR.Subdomain, validTxtData, 401},
+		{newUserWithValidCIDR.Username.String(), newUserWithValidCIDR.Password, newUserWithValidCIDR.Subdomain, validTxtData, 200},
+		{newUser.Username.String(), "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", newUser.Subdomain, validTxtData, 401},
+	} {
+		updateJSON = map[string]interface{}{
+			"subdomain": test.subdomain,
+			"txt":       test.txt}
+		e.POST("/delete").
+			WithJSON(updateJSON).
+			WithHeader("X-Api-User", test.user).
+			WithHeader("X-Api-Key", test.pass).
+			WithHeader("X-Forwarded-For", "10.1.2.3").
+			Expect().
+			Status(test.status)
+	}
+}
+
 func TestApiManyUpdateWithIpCheckHeaders(t *testing.T) {
 
 	router := setupRouter(false, false)
@@ -421,6 +615,62 @@ func TestApiManyUpdateWithIpCheckHeaders(t *testing.T) {
 			"subdomain": test.user.Subdomain,
 			"txt":       "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}
 		e.POST("/update").
+			WithJSON(updateJSON).
+			WithHeader("X-Api-User", test.user.Username.String()).
+			WithHeader("X-Api-Key", test.user.Password).
+			WithHeader("X-Forwarded-For", test.headerValue).
+			Expect().
+			Status(test.status)
+	}
+	Config.API.UseHeader = false
+}
+
+func TestApiManyDeleteWithIpCheckHeaders(t *testing.T) {
+
+	updateJSON := map[string]interface{}{
+		"subdomain": "",
+		"txt":       ""}
+
+	router := setupRouter(false, false)
+	server := httptest.NewServer(router)
+	defer server.Close()
+	e := getExpect(t, server)
+	// Use header checks from default header (X-Forwarded-For)
+	Config.API.UseHeader = true
+	// User without defined CIDR masks
+	newUser, err := DB.Register(cidrslice{})
+	if err != nil {
+		t.Errorf("Could not create new user, got error [%v]", err)
+	}
+
+	newUserWithCIDR, err := DB.Register(cidrslice{"192.168.1.2/32", "invalid"})
+	if err != nil {
+		t.Errorf("Could not create new user with CIDR, got error [%v]", err)
+	}
+
+	newUserWithIP6CIDR, err := DB.Register(cidrslice{"2002:c0a8::0/32"})
+	if err != nil {
+		t.Errorf("Could not create a new user with IP6 CIDR, got error [%v]", err)
+	}
+
+	for _, test := range []struct {
+		user        ACMETxt
+		headerValue string
+		status      int
+	}{
+		{newUser, "whatever goes", 200},
+		{newUser, "10.0.0.1, 1.2.3.4 ,3.4.5.6", 200},
+		{newUserWithCIDR, "127.0.0.1", 401},
+		{newUserWithCIDR, "10.0.0.1, 10.0.0.2, 192.168.1.3", 401},
+		{newUserWithCIDR, "10.1.1.1 ,192.168.1.2, 8.8.8.8", 200},
+		{newUserWithIP6CIDR, "2002:c0a8:b4dc:0d3::0", 200},
+		{newUserWithIP6CIDR, "2002:c0a7:0ff::0", 401},
+		{newUserWithIP6CIDR, "2002:c0a8:d3ad:b33f:c0ff:33b4:dc0d:3b4d", 200},
+	} {
+		updateJSON = map[string]interface{}{
+			"subdomain": test.user.Subdomain,
+			"txt":       "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}
+		e.POST("/delete").
 			WithJSON(updateJSON).
 			WithHeader("X-Api-User", test.user.Username.String()).
 			WithHeader("X-Api-Key", test.user.Password).

--- a/api_test.go
+++ b/api_test.go
@@ -515,10 +515,6 @@ func TestApiManyUpdateWithCredentials(t *testing.T) {
 func TestApiManyDeleteWithCredentials(t *testing.T) {
 	validTxtData := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 
-	updateJSON := map[string]interface{}{
-		"subdomain": "",
-		"txt":       ""}
-
 	router := setupRouter(true, false)
 	server := httptest.NewServer(router)
 	defer server.Close()
@@ -560,7 +556,7 @@ func TestApiManyDeleteWithCredentials(t *testing.T) {
 		{newUserWithValidCIDR.Username.String(), newUserWithValidCIDR.Password, newUserWithValidCIDR.Subdomain, validTxtData, 200},
 		{newUser.Username.String(), "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", newUser.Subdomain, validTxtData, 401},
 	} {
-		updateJSON = map[string]interface{}{
+		updateJSON := map[string]interface{}{
 			"subdomain": test.subdomain,
 			"txt":       test.txt}
 		e.POST("/delete").
@@ -626,11 +622,6 @@ func TestApiManyUpdateWithIpCheckHeaders(t *testing.T) {
 }
 
 func TestApiManyDeleteWithIpCheckHeaders(t *testing.T) {
-
-	updateJSON := map[string]interface{}{
-		"subdomain": "",
-		"txt":       ""}
-
 	router := setupRouter(false, false)
 	server := httptest.NewServer(router)
 	defer server.Close()
@@ -667,7 +658,7 @@ func TestApiManyDeleteWithIpCheckHeaders(t *testing.T) {
 		{newUserWithIP6CIDR, "2002:c0a7:0ff::0", 401},
 		{newUserWithIP6CIDR, "2002:c0a8:d3ad:b33f:c0ff:33b4:dc0d:3b4d", 200},
 	} {
-		updateJSON = map[string]interface{}{
+		updateJSON := map[string]interface{}{
 			"subdomain": test.user.Subdomain,
 			"txt":       "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}
 		e.POST("/delete").

--- a/db.go
+++ b/db.go
@@ -17,7 +17,7 @@ import (
 )
 
 // DBVersion shows the database version this code uses. This is used for update checks.
-var DBVersion = 1
+var DBVersion = 2
 
 var acmeTable = `
 	CREATE TABLE IF NOT EXISTS acmedns(
@@ -25,27 +25,20 @@ var acmeTable = `
 		Value TEXT
 	);`
 
-var userTable = `
+var recordsTable = `
 	CREATE TABLE IF NOT EXISTS records(
         Username TEXT UNIQUE NOT NULL PRIMARY KEY,
         Password TEXT UNIQUE NOT NULL,
         Subdomain TEXT UNIQUE NOT NULL,
-		AllowFrom TEXT
+	AllowFrom TEXT,
+	LastUsed, INT
     );`
 
 var txtTable = `
     CREATE TABLE IF NOT EXISTS txt(
 		Subdomain TEXT NOT NULL,
 		Value   TEXT NOT NULL DEFAULT '',
-		LastUpdate INT
-	);`
-
-var txtTablePG = `
-    CREATE TABLE IF NOT EXISTS txt(
-		rowid SERIAL,
-		Subdomain TEXT NOT NULL,
-		Value   TEXT NOT NULL DEFAULT '',
-		LastUpdate INT
+	        InsertDate, INT
 	);`
 
 // getSQLiteStmt replaces all PostgreSQL prepared statement placeholders (eg. $1, $2) with SQLite variant "?"
@@ -62,18 +55,21 @@ func (d *acmedb) Init(engine string, connection string) error {
 		return err
 	}
 	d.DB = db
-	// Check version first to try to catch old versions without version string
+	// create tables if they don't exist
+	_, err = d.DB.Exec("SELECT COUNT(*) from txt")
+	if err != nil && (err.Error() == `no such table: txt` || err.Error() == `relation "txt" does not exist`) {
+		log.Info("Creating tables")
+		_, _ = d.DB.Exec(acmeTable)
+		_, _ = d.DB.Exec(recordsTable)
+		_, _ = d.DB.Exec(txtTable)
+		insversion := fmt.Sprintf("INSERT INTO acmedns (Name, Value) values('db_version', '%d')", DBVersion)
+		_, err = db.Exec(insversion)
+	}
+
 	var versionString string
 	_ = d.DB.QueryRow("SELECT Value FROM acmedns WHERE Name='db_version'").Scan(&versionString)
 	if versionString == "" {
 		versionString = "0"
-	}
-	_, _ = d.DB.Exec(acmeTable)
-	_, _ = d.DB.Exec(userTable)
-	if Config.Database.Engine == "sqlite3" {
-		_, _ = d.DB.Exec(txtTable)
-	} else {
-		_, _ = d.DB.Exec(txtTablePG)
 	}
 	// If everything is fine, handle db upgrade tasks
 	if err == nil {
@@ -103,8 +99,15 @@ func (d *acmedb) checkDBUpgrades(versionString string) error {
 }
 
 func (d *acmedb) handleDBUpgrades(version int) error {
-	if version == 0 {
-		return d.handleDBUpgradeTo1()
+	var err error
+	if version < 1 {
+		err = d.handleDBUpgradeTo1()
+		if err != nil {
+			return err
+		}
+	}
+	if version < 2 {
+		return d.handleDBUpgradeTo2()
 	}
 	return nil
 }
@@ -112,6 +115,7 @@ func (d *acmedb) handleDBUpgrades(version int) error {
 func (d *acmedb) handleDBUpgradeTo1() error {
 	var err error
 	var subdomains []string
+	log.Info("Upgrading db to version 1")
 	rows, err := d.DB.Query("SELECT Subdomain FROM records")
 	if err != nil {
 		log.WithFields(log.Fields{"error": err.Error()}).Error("Error in DB upgrade")
@@ -142,16 +146,6 @@ func (d *acmedb) handleDBUpgradeTo1() error {
 		_ = tx.Commit()
 	}()
 	_, _ = tx.Exec("DELETE FROM txt")
-	for _, subdomain := range subdomains {
-		if subdomain != "" {
-			// Insert two rows for each subdomain to txt table
-			err = d.NewTXTValuesInTransaction(tx, subdomain)
-			if err != nil {
-				log.WithFields(log.Fields{"error": err.Error()}).Error("Error in DB upgrade while inserting values")
-				return err
-			}
-		}
-	}
 	// SQLite doesn't support dropping columns
 	if Config.Database.Engine != "sqlite3" {
 		_, _ = tx.Exec("ALTER TABLE records DROP COLUMN IF EXISTS Value")
@@ -160,13 +154,28 @@ func (d *acmedb) handleDBUpgradeTo1() error {
 	_, err = tx.Exec("UPDATE acmedns SET Value='1' WHERE Name='db_version'")
 	return err
 }
-
-// Create two rows for subdomain to the txt table
-func (d *acmedb) NewTXTValuesInTransaction(tx *sql.Tx, subdomain string) error {
+func (d *acmedb) handleDBUpgradeTo2() error {
 	var err error
-	instr := fmt.Sprintf("INSERT INTO txt (Subdomain, LastUpdate) values('%s', 0)", subdomain)
-	_, _ = tx.Exec(instr)
-	_, _ = tx.Exec(instr)
+	log.Info("Upgrading db to version 2")
+	tx, err := d.DB.Begin()
+	// Rollback if errored, commit if not
+	defer func() {
+		if err != nil {
+			_ = tx.Rollback()
+			return
+		}
+		_ = tx.Commit()
+	}()
+	_, _ = tx.Exec("ALTER TABLE records ADD COLUMN LastUsed INT");
+	if err != nil {
+		return err
+	}
+	_, err = tx.Exec("ALTER TABLE txt RENAME COLUMN LastUpdate to InsertDate")
+	if err != nil {
+		return err
+	}
+
+	_, err = tx.Exec("UPDATE acmedns SET Value='2' WHERE Name='db_version'")
 	return err
 }
 
@@ -203,9 +212,6 @@ func (d *acmedb) Register(afrom cidrslice) (ACMETxt, error) {
 	}
 	defer sm.Close()
 	_, err = sm.Exec(a.Username.String(), passwordHash, a.Subdomain, a.AllowFrom.JSON())
-	if err == nil {
-		err = d.NewTXTValuesInTransaction(tx, a.Subdomain)
-	}
 	return a, err
 }
 
@@ -252,8 +258,9 @@ func (d *acmedb) GetTXTForDomain(domain string) ([]string, error) {
 	defer d.Unlock()
 	domain = sanitizeString(domain)
 	var txts []string
+	// limit records, because a acme-dns cert may not contain more than 100 domains
 	getSQL := `
-	SELECT Value FROM txt WHERE Subdomain=$1 AND LastUpdate > 0 LIMIT 2
+	SELECT Value FROM txt WHERE Subdomain=$1 ORDER BY InsertDate DESC LIMIT 100
 	`
 	if Config.Database.Engine == "sqlite3" {
 		getSQL = getSQLiteStmt(getSQL)
@@ -288,25 +295,32 @@ func (d *acmedb) Update(a ACMETxtPost) error {
 	// Data in a is already sanitized
 	timenow := time.Now().Unix()
 
-	updSQL := `
-	UPDATE txt SET Value=$1, LastUpdate=$2
-	WHERE rowid=(
-		SELECT rowid FROM txt WHERE Subdomain=$3 ORDER BY LastUpdate LIMIT 1)
-	`
+	updSQL := `INSERT INTO txt (Subdomain, Value, InsertDate) values($1, $2, $3)`
 	if Config.Database.Engine == "sqlite3" {
 		updSQL = getSQLiteStmt(updSQL)
 	}
 
-	sm, err := d.DB.Prepare(updSQL)
+	updStmt, err := d.DB.Prepare(updSQL)
 	if err != nil {
 		return err
 	}
-	defer sm.Close()
-	_, err = sm.Exec(a.Value, timenow, a.Subdomain)
+	defer updStmt.Close()
+	_, err = updStmt.Exec(a.Subdomain, a.Value, timenow)
 	if err != nil {
 		return err
 	}
-	return nil
+
+	lastUsedSQL := `UPDATE records SET LastUsed = $1 WHERE Subdomain = $2`
+	lastUsedStmt, err := d.DB.Prepare(lastUsedSQL)
+	defer lastUsedStmt.Close()
+	if err != nil {
+		return err
+	}
+	if err != nil {
+		return err
+	}
+	_, err = lastUsedStmt.Exec(timenow, a.Subdomain)
+	return err
 }
 
 func (d *acmedb) Delete(a ACMETxtPost) error {
@@ -315,11 +329,7 @@ func (d *acmedb) Delete(a ACMETxtPost) error {
 	var err error
 	// Data in a is already sanitized
 
-	delSQL := `
-	UPDATE txt SET LastUpdate=0
-	WHERE rowid=(
-		SELECT rowid FROM txt WHERE Subdomain=$1 AND Value=$2)
-	`
+	delSQL := `DELETE FROM txt WHERE Subdomain=$1 AND Value=$2`
 	if Config.Database.Engine == "sqlite3" {
 		delSQL = getSQLiteStmt(delSQL)
 	}
@@ -330,10 +340,7 @@ func (d *acmedb) Delete(a ACMETxtPost) error {
 	}
 	defer sm.Close()
 	_, err = sm.Exec(a.Subdomain, a.Value)
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }
 
 func getModelFromRow(r *sql.Rows) (ACMETxt, error) {

--- a/db.go
+++ b/db.go
@@ -114,28 +114,7 @@ func (d *acmedb) handleDBUpgrades(version int) error {
 
 func (d *acmedb) handleDBUpgradeTo1() error {
 	var err error
-	var subdomains []string
 	log.Info("Upgrading db to version 1")
-	rows, err := d.DB.Query("SELECT Subdomain FROM records")
-	if err != nil {
-		log.WithFields(log.Fields{"error": err.Error()}).Error("Error in DB upgrade")
-		return err
-	}
-	defer rows.Close()
-	for rows.Next() {
-		var subdomain string
-		err = rows.Scan(&subdomain)
-		if err != nil {
-			log.WithFields(log.Fields{"error": err.Error()}).Error("Error in DB upgrade while reading values")
-			return err
-		}
-		subdomains = append(subdomains, subdomain)
-	}
-	err = rows.Err()
-	if err != nil {
-		log.WithFields(log.Fields{"error": err.Error()}).Error("Error in DB upgrade while inserting values")
-		return err
-	}
 	tx, err := d.DB.Begin()
 	// Rollback if errored, commit if not
 	defer func() {
@@ -312,10 +291,10 @@ func (d *acmedb) Update(a ACMETxtPost) error {
 
 	lastUsedSQL := `UPDATE records SET LastUsed = $1 WHERE Subdomain = $2`
 	lastUsedStmt, err := d.DB.Prepare(lastUsedSQL)
-	defer lastUsedStmt.Close()
 	if err != nil {
 		return err
 	}
+	defer lastUsedStmt.Close()
 	if err != nil {
 		return err
 	}

--- a/dns_test.go
+++ b/dns_test.go
@@ -15,6 +15,13 @@ type resolver struct {
 	server string
 }
 
+type testRecord struct {
+	subDomain   string
+	expTXT      []string
+	getAnswer   bool
+	validAnswer bool
+}
+
 func (r *resolver) lookup(host string, qtype uint16) (*dns.Msg, error) {
 	msg := new(dns.Msg)
 	msg.Id = dns.Id()
@@ -31,13 +38,21 @@ func (r *resolver) lookup(host string, qtype uint16) (*dns.Msg, error) {
 	return in, nil
 }
 
-func hasExpectedTXTAnswer(answer []dns.RR, cmpTXT string) error {
+func hasExpectedTXTAnswer(answer []dns.RR, cmpTXT []string) error {
+	matches := 0
+	txts := 0
+
+OUTER:
 	for _, record := range answer {
-		// We expect only one answer, so no need to loop through the answer slice
+		// Verify all expected answers are returned
 		if rec, ok := record.(*dns.TXT); ok {
 			for _, txtValue := range rec.Txt {
-				if txtValue == cmpTXT {
-					return nil
+				txts++
+				for _, cmpValue := range cmpTXT {
+					if txtValue == cmpValue {
+						matches++
+						continue OUTER
+					}
 				}
 			}
 		} else {
@@ -45,7 +60,70 @@ func hasExpectedTXTAnswer(answer []dns.RR, cmpTXT string) error {
 			return errors.New(errmsg)
 		}
 	}
-	return errors.New("Expected answer not found")
+
+	//Got too many results
+	if txts > len(cmpTXT) {
+		errmsg := fmt.Sprintf("Got too many answers [%d > %d]", txts, len(cmpTXT))
+		return errors.New(errmsg)
+	} else if txts < len(cmpTXT) {
+		//Got too few results
+		errmsg := fmt.Sprintf("Got too few answers [%d < %d]", txts, len(cmpTXT))
+		return errors.New(errmsg)
+	} else if matches > len(cmpTXT) {
+		//Got too many matches
+		errmsg := fmt.Sprintf("Got too many matches [%d > %d]", matches, len(cmpTXT))
+		return errors.New(errmsg)
+	} else if matches < len(cmpTXT) {
+		//Got not enough matches
+		errmsg := fmt.Sprintf("Got too few matches [%d < %d]", matches, len(cmpTXT))
+		return errors.New(errmsg)
+	} else if matches == len(cmpTXT) {
+		//If they all matched we are ok
+		return nil
+	}
+
+	return errors.New("Expected answer(s) not found")
+}
+
+func hasExpectedResolveTXTs(tests []testRecord) error {
+	resolv := resolver{server: "127.0.0.1:15353"}
+
+	for i, test := range tests {
+		answer, err := resolv.lookup(test.subDomain+".auth.example.org", dns.TypeTXT)
+		if err != nil {
+			if test.getAnswer {
+				return fmt.Errorf("%d: Expected answer but got: %v", i, err)
+			}
+		} else {
+			if !test.getAnswer {
+				return fmt.Errorf("%d: Expected no answer, but got one", i)
+			}
+		}
+
+		if len(answer.Answer) > 0 {
+			if !test.getAnswer && answer.Answer[0].Header().Rrtype != dns.TypeSOA {
+				return fmt.Errorf("%d: Expected no answer, but got: [%q]", i, answer)
+			}
+			if test.getAnswer {
+				err = hasExpectedTXTAnswer(answer.Answer, test.expTXT)
+				if err != nil {
+					if test.validAnswer {
+						return fmt.Errorf("%d: %v", i, err)
+					}
+				} else {
+					if !test.validAnswer {
+						return fmt.Errorf("%d: Answer was not expected to be valid, answer [%q], compared to [%s]", i, answer, test.expTXT)
+					}
+				}
+			}
+		} else {
+			if test.getAnswer {
+				return fmt.Errorf("%d: Expected answer, but didn't get one", i)
+			}
+		}
+	}
+
+	return nil
 }
 
 func TestQuestionDBError(t *testing.T) {
@@ -196,8 +274,8 @@ func TestAuthoritative(t *testing.T) {
 }
 
 func TestResolveTXT(t *testing.T) {
-	resolv := resolver{server: "127.0.0.1:15353"}
 	validTXT := "______________valid_response_______________"
+	validTXT2 := "_____________valid_response_2______________"
 
 	atxt, err := DB.Register(cidrslice{})
 	if err != nil {
@@ -211,49 +289,74 @@ func TestResolveTXT(t *testing.T) {
 		return
 	}
 
-	for i, test := range []struct {
-		subDomain   string
-		expTXT      string
-		getAnswer   bool
-		validAnswer bool
-	}{
-		{atxt.Subdomain, validTXT, true, true},
-		{atxt.Subdomain, "invalid", true, false},
-		{"a097455b-52cc-4569-90c8-7a4b97c6eba8", validTXT, false, false},
-	} {
-		answer, err := resolv.lookup(test.subDomain+".auth.example.org", dns.TypeTXT)
-		if err != nil {
-			if test.getAnswer {
-				t.Fatalf("Test %d: Expected answer but got: %v", i, err)
-			}
-		} else {
-			if !test.getAnswer {
-				t.Errorf("Test %d: Expected no answer, but got one.", i)
-			}
-		}
-
-		if len(answer.Answer) > 0 {
-			if !test.getAnswer && answer.Answer[0].Header().Rrtype != dns.TypeSOA {
-				t.Errorf("Test %d: Expected no answer, but got: [%q]", i, answer)
-			}
-			if test.getAnswer {
-				err = hasExpectedTXTAnswer(answer.Answer, test.expTXT)
-				if err != nil {
-					if test.validAnswer {
-						t.Errorf("Test %d: %v", i, err)
-					}
-				} else {
-					if !test.validAnswer {
-						t.Errorf("Test %d: Answer was not expected to be valid, answer [%q], compared to [%s]", i, answer, test.expTXT)
-					}
-				}
-			}
-		} else {
-			if test.getAnswer {
-				t.Errorf("Test %d: Expected answer, but didn't get one", i)
-			}
-		}
+	seq := 0
+	err = hasExpectedResolveTXTs([]testRecord{
+		{atxt.Subdomain, []string{validTXT}, true, true},
+		{atxt.Subdomain, []string{"invalid"}, true, false},
+		{"a097455b-52cc-4569-90c8-7a4b97c6eba8", []string{validTXT}, false, false},
+	})
+	if err != nil {
+		t.Fatalf("Test %d: %s", seq, err)
+		return
 	}
+	seq++
+
+	//Add 2nd record and verify it works as expected (both results)
+	atxt.Value = validTXT2
+	err = DB.Update(atxt.ACMETxtPost)
+	if err != nil {
+		t.Errorf("Could not update db record: [%v]", err)
+		return
+	}
+
+	err = hasExpectedResolveTXTs([]testRecord{
+		{atxt.Subdomain, []string{validTXT, validTXT2}, true, true},
+		{atxt.Subdomain, []string{"invalid"}, true, false},
+		{"a097455b-52cc-4569-90c8-7a4b97c6eba8", []string{validTXT}, false, false},
+	})
+	if err != nil {
+		t.Fatalf("Test %d: %s", seq, err)
+		return
+	}
+	seq++
+
+	//Delete the record and rerun the test, should see only first result again
+	atxt.Value = validTXT2
+	err = DB.Delete(atxt.ACMETxtPost)
+	if err != nil {
+		t.Errorf("Could not delete db record: [%v]", err)
+		return
+	}
+
+	err = hasExpectedResolveTXTs([]testRecord{
+		{atxt.Subdomain, []string{validTXT}, true, true},
+		{atxt.Subdomain, []string{"invalid"}, true, false},
+		{"a097455b-52cc-4569-90c8-7a4b97c6eba8", []string{validTXT}, false, false},
+	})
+	if err != nil {
+		t.Fatalf("Test %d: %s", seq, err)
+		return
+	}
+	seq++
+
+	//Delete the record and rerun the test, should see nothing
+	atxt.Value = validTXT
+	err = DB.Delete(atxt.ACMETxtPost)
+	if err != nil {
+		t.Errorf("Could not delete db record: [%v]", err)
+		return
+	}
+
+	err = hasExpectedResolveTXTs([]testRecord{
+		{atxt.Subdomain, []string{"empty"}, false, false},
+		{atxt.Subdomain, []string{"invalid"}, false, false},
+		{"a097455b-52cc-4569-90c8-7a4b97c6eba8", []string{validTXT}, false, false},
+	})
+	if err != nil {
+		t.Fatalf("Test %d: %s", seq, err)
+		return
+	}
+	seq++
 }
 
 func TestCaseInsensitiveResolveA(t *testing.T) {

--- a/dns_test.go
+++ b/dns_test.go
@@ -356,7 +356,6 @@ func TestResolveTXT(t *testing.T) {
 		t.Fatalf("Test %d: %s", seq, err)
 		return
 	}
-	seq++
 }
 
 func TestCaseInsensitiveResolveA(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -126,6 +126,7 @@ func startHTTPAPI(errChan chan error, config DNSConfig, dnsservers []*DNSServer)
 		api.POST("/register", webRegisterPost)
 	}
 	api.POST("/update", Auth(webUpdatePost))
+	api.POST("/delete", Auth(webDeletePost))
 	api.GET("/health", healthCheck)
 
 	host := Config.API.IP + ":" + Config.API.Port

--- a/types.go
+++ b/types.go
@@ -73,6 +73,7 @@ type database interface {
 	GetByUsername(uuid.UUID) (ACMETxt, error)
 	GetTXTForDomain(string) ([]string, error)
 	Update(ACMETxtPost) error
+	Delete(ACMETxtPost) error
 	GetBackend() *sql.DB
 	SetBackend(*sql.DB)
 	Close()


### PR DESCRIPTION
This PR builds on the work of @jacobmyers-codeninja's PR #245 and fully implements set-and-delete flow.

This fixes issues such as https://github.com/dehydrated-io/dehydrated/issues/832