### PR TITLE
rebase acme-dns docker image on google distroless

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,28 @@
-FROM golang:1.13-alpine AS builder
+FROM --platform=amd64 golang:1-alpine AS builder
 LABEL maintainer="joona@kuori.org"
 
 RUN apk add --update gcc musl-dev git
 
-ENV GOPATH /tmp/buildcache
-RUN git clone https://github.com/joohoi/acme-dns /tmp/acme-dns
+RUN git clone --depth=1 https://github.com/joohoi/acme-dns /tmp/acme-dns
+
+ENV GOPATH       /tmp/buildcache
+ENV CGO_ENABLED  1
 WORKDIR /tmp/acme-dns
-RUN CGO_ENABLED=1 go build
+RUN go build -ldflags="-extldflags=-static"
 
-FROM alpine:latest
+# assemble the release ready to copy to the image.
+RUN mkdir -p /tmp/release/bin
+RUN mkdir -p /tmp/release/etc/acme-dns
+RUN mkdir -p /tmp/release/var/lib/acme-dns
+RUN cp /tmp/acme-dns/acme-dns /tmp/release/bin/acme-dns
 
-WORKDIR /root/
-COPY --from=builder /tmp/acme-dns .
-RUN mkdir -p /etc/acme-dns
-RUN mkdir -p /var/lib/acme-dns
-RUN rm -rf ./config.cfg
-RUN apk --no-cache add ca-certificates && update-ca-certificates
+
+FROM gcr.io/distroless/static
+
+WORKDIR /
+COPY --from=builder /tmp/release .
 
 VOLUME ["/etc/acme-dns", "/var/lib/acme-dns"]
-ENTRYPOINT ["./acme-dns"]
+ENTRYPOINT ["/bin/acme-dns"]
 EXPOSE 53 80 443
 EXPOSE 53/udp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=amd64 golang:1-alpine AS builder
+FROM golang:1-alpine AS builder
 LABEL maintainer="joona@kuori.org"
 
 RUN apk add --update gcc musl-dev git


### PR DESCRIPTION
This rewritten Dockerfile improves the acme-dns image in a number of ways:

It uses the GoogleContainerTools/distroless static image as base, removing
everything from the container including the shell, dynamic linker, etc.

It builds a fully static acme-dns binary, including static-linking the CGO
components, to be able to run without any dynamic linking, or libc, on the
target system.

It assembles the "release" layout of the application and support directories
on the builder, then copies them wholesale to the final image.

It *only* copies the `acme-dns` binary; it exclused the `.git` directory,
and all other files, that are shipped in the current image.

It uses a shallow checkout to build, which is appropriate since the builder
is a throw-away image and will be destroyed when the build process is done.


Limitations:

The distroless image doesn't provide anything beyond the bare minimum to run
the static binary – notably, no `/bin/sh` is present.

If this is a concern the best strategy would be to add a second image,
deploying `FROM gcr.io/distroless/static:debug` which provides busybod as
`/bin/sh` and the rest of the standard utilities.

I have not implemented this solution at this time.


Background:

The Google distroless images provide a base for running software containers
with the absolute bare minimum of files.  For more details see
https://github.com/GoogleContainerTools/distroless

This bases the acme-dns docker image off the distroless "static" image,
`gcr.io/distroless/static`, which is suitable for running fully static
application in languages like go – it has no dynamic linker.