### PR TITLE
Strict decoding of config file

### DIFF
--- a/pkg/acmedns/config.go
+++ b/pkg/acmedns/config.go
@@ -30,16 +30,23 @@ func FileIsAccessible(fname string) bool {
 
 func readTomlConfig(fname string) (AcmeDnsConfig, error) {
 	var conf AcmeDnsConfig
-	_, err := toml.DecodeFile(fname, &conf)
+	md, err := toml.DecodeFile(fname, &conf)
 	if err != nil {
 		// Return with config file parsing errors from toml package
 		return conf, err
+	}
+	undecoded := md.Undecoded()
+	if len(undecoded) > 0 {
+		return conf, fmt.Errorf("Unexpected keys: %v", undecoded)
 	}
 	return prepareConfig(conf)
 }
 
 // prepareConfig checks that mandatory values exist, and can be used to set default values in the future
 func prepareConfig(conf AcmeDnsConfig) (AcmeDnsConfig, error) {
+	if conf.General.Domain == "" {
+		return conf, errors.New("missing general configuration option \"domain\"")
+	}
 	if conf.Database.Engine == "" {
 		return conf, errors.New("missing database configuration option \"engine\"")
 	}

--- a/pkg/acmedns/util_test.go
+++ b/pkg/acmedns/util_test.go
@@ -264,16 +264,22 @@ func TestPrepareConfig(t *testing.T) {
 		shoulderror bool
 	}{
 		{AcmeDnsConfig{
+			General:  general{Domain: "example.com"},
 			Database: dbsettings{Engine: "whatever", Connection: "whatever_too"},
 			API:      httpapi{TLS: ApiTlsProviderNone},
 		}, false},
-		{AcmeDnsConfig{Database: dbsettings{Engine: "", Connection: "whatever_too"},
-			API: httpapi{TLS: ApiTlsProviderNone},
-		}, true},
-		{AcmeDnsConfig{Database: dbsettings{Engine: "whatever", Connection: ""},
-			API: httpapi{TLS: ApiTlsProviderNone},
+		{AcmeDnsConfig{
+			General:  general{Domain: "example.com"},
+			Database: dbsettings{Engine: "", Connection: "whatever_too"},
+			API:      httpapi{TLS: ApiTlsProviderNone},
 		}, true},
 		{AcmeDnsConfig{
+			General:  general{Domain: "example.com"},
+			Database: dbsettings{Engine: "whatever", Connection: ""},
+			API:      httpapi{TLS: ApiTlsProviderNone},
+		}, true},
+		{AcmeDnsConfig{
+			General:  general{Domain: "example.com"},
 			Database: dbsettings{Engine: "whatever", Connection: "whatever_too"},
 			API:      httpapi{TLS: "whatever"},
 		}, true},
@@ -285,7 +291,7 @@ func TestPrepareConfig(t *testing.T) {
 			}
 		} else {
 			if err != nil {
-				t.Errorf("Test %d: Expected no error with prepareConfig input data [%v]", i, test.input)
+				t.Errorf("Test %d: Expected no error with prepareConfig input data [%v], got %s", i, test.input, err)
 			}
 		}
 	}


### PR DESCRIPTION
Abort on unrecognized options or if general.domain is missing

Fixes #292