### PR TITLE
Refactor & automatically build Docker image

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,92 @@
+name: Docker
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+on:
+  push:
+    branches: [ "master" ]
+    # Publish semver tags as releases.
+    tags: [ 'v*.*.*' ]
+
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      # This is used to complete the identity challenge
+      # with sigstore/fulcio when running outside of PRs.
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      # Install the cosign tool except on PR
+      # https://github.com/sigstore/cosign-installer
+      - name: Install cosign
+        if: github.event_name != 'pull_request'
+        uses: sigstore/cosign-installer@f3c664df7af409cb4873aa5068053ba9d61a57b6 #v2.6.0
+        with:
+          cosign-release: 'v1.13.1'
+
+
+      # Workaround: https://github.com/docker/build-push-action/issues/461
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@79abd3f86f79a9d68a23c75a09a9a85889262adf
+
+      # Login against a Docker registry except on PR
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+
+      # Sign the resulting Docker image digest except on PRs.
+      # This will only write to the public Rekor transparency log when the Docker
+      # repository is public to avoid leaking data.  If you would like to publish
+      # transparency data even for private images, pass --force to cosign below.
+      # https://github.com/sigstore/cosign
+      - name: Sign the published Docker image
+        if: ${{ github.event_name != 'pull_request' }}
+        env:
+          COSIGN_EXPERIMENTAL: "true"
+        # This step uses the identity token to provision an ephemeral certificate
+        # against the sigstore community Fulcio instance.
+        run: echo "${{ steps.meta.outputs.tags }}" | xargs -I {} cosign sign {}@${{ steps.build-and-push.outputs.digest }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,25 @@
 FROM golang:alpine AS builder
 LABEL maintainer="joona@kuori.org"
 
+# required for sqlite/CGO:
 RUN apk add --update gcc musl-dev git
-
-ENV GOPATH /tmp/buildcache
-RUN git clone https://github.com/joohoi/acme-dns /tmp/acme-dns
 WORKDIR /tmp/acme-dns
+ADD go.mod go.sum ./
+RUN go mod download
+# generally cacheable steps until here
+ADD *.go ./
 RUN CGO_ENABLED=1 go build
 
-FROM alpine:latest
 
-WORKDIR /root/
-COPY --from=builder /tmp/acme-dns .
-RUN mkdir -p /etc/acme-dns
-RUN mkdir -p /var/lib/acme-dns
-RUN rm -rf ./config.cfg
+FROM alpine:latest
+# required for getting LE certs for the API:
 RUN apk --no-cache add ca-certificates && update-ca-certificates
+RUN adduser -D -u 1000 -h /var/lib/acme-dns acme-dns
+RUN mkdir -p /etc/acme-dns
+WORKDIR /var/lib/acme-dns
+USER 1000
+COPY --from=builder /tmp/acme-dns/acme-dns /usr/local/bin/acme-dns
 
 VOLUME ["/etc/acme-dns", "/var/lib/acme-dns"]
-ENTRYPOINT ["./acme-dns"]
-EXPOSE 53 80 443
-EXPOSE 53/udp
+ENTRYPOINT ["acme-dns"]
+EXPOSE 8053 8053/udp 8080 8443

--- a/README.md
+++ b/README.md
@@ -160,14 +160,14 @@ go build
 
 3) Copy [configuration template](https://raw.githubusercontent.com/joohoi/acme-dns/master/config.cfg) to `config/config.cfg`.
 
-4) Modify the `config.cfg` to suit your needs.
+4) Modify the `config.cfg` to suit your needs. Note that since acme-dns does not run as root inside the container, you may have to use ports >1024 in your config.
 
 5) Run Docker, this example expects that you have `port = "80"` in your `config.cfg`:
 ```
 docker run --rm --name acmedns                 \
- -p 53:53                                      \
- -p 53:53/udp                                  \
- -p 80:80                                      \
+ -p 53:8053                                    \
+ -p 53:8053/udp                                \
+ -p 80:8080                                    \
  -v /path/to/your/config:/etc/acme-dns:ro      \
  -v /path/to/your/data:/var/lib/acme-dns       \
  -d joohoi/acme-dns

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,10 +6,10 @@ services:
       dockerfile: Dockerfile
     image: joohoi/acme-dns:latest
     ports:
-      - "443:443"
-      - "53:53"
-      - "53:53/udp"
-      - "80:80"
+      - "443:8443"
+      - "53:8053"
+      - "53:8053/udp"
+      - "80:8080"
     volumes:
       - ./config:/etc/acme-dns:ro
       - ./data:/var/lib/acme-dns


### PR DESCRIPTION
- Refactor Dockerfile
  - Use code from context instead of cloning the repo
  - Download dependencies first for caching
  - Run as unprivileged account (note that this break running on ports
    <1024 on Docker <20.03; default ports changed accordingly)
- I'm not actually sure the ca-certificates package is required in the image, requesting certificates seems to work without it, though I did not test fully obtaining one.
- Automatically build and deploy Docker image via GitHub Actions
  - I mainly did this so I can use it right away. Dunno if it makes sense, especially since images are on Docker Hub already.
